### PR TITLE
Improved the "setup" notice making it easier to copy/paste the commands

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,8 +4,10 @@ $loader = @include __DIR__ . '/../vendor/autoload.php';
 if (!$loader) {
     die(<<<'EOT'
 You must set up the project dependencies, run the following commands:
+
 wget http://getcomposer.org/composer.phar
 php composer.phar install
+
 EOT
     );
 }


### PR DESCRIPTION
Before:

``` bash
user@host ~/assert master $ phpunit
You must set up the project dependencies, run the following commands:
wget http://getcomposer.org/composer.phar
php composer.phar install user@host ~/assert master $ 
```

After:

``` bash
user@host ~/assert master $ phpunit
You must set up the project dependencies, run the following commands:

wget http://getcomposer.org/composer.phar
php composer.phar install
user@host ~/assert master $ 
```
