### PR TITLE
Added tests for `file` and fixed throwing the exception

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -504,9 +504,10 @@ class Assertion
     static public function file($value, $message = null, $propertyPath = null)
     {
         static::string($value, $message);
+        static::notEmpty($value, $message);
 
         if ( ! is_file($value)) {
-            throw static::createException($message, static::INVALID_FILE);
+            throw static::createException($message, static::INVALID_FILE, $propertyPath);
         }
     }
 

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -390,6 +390,23 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_LENGTH);
         Assertion::length("asdf", 3);
     }
+
+    public function testFile()
+    {
+        Assertion::file(__FILE__);
+    }
+
+    public function testFileWithEmptyFilename()
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::VALUE_EMPTY);
+        Assertion::file("");
+    }
+
+    public function testFileDoesNotExists()
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_FILE);
+        Assertion::file(__DIR__ . '/does-not-exists');
+    }
 }
 
 class ChildStdClass extends \stdClass


### PR DESCRIPTION
Fixes:

> Missing argument 3 for Assert\Assertion::createException(), called in .../assert/lib/Assert/Assertion.php on line 510

when `file` fails.

Also added tests for the `file` function
