### PR TITLE
Allow min/max/range values to be any number type

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -903,7 +903,7 @@ class Assertion
     }
 
     /**
-     * Assert that value is in range of integers.
+     * Assert that value is in range of numbers.
      *
      * @param mixed $value
      * @param integer $minValue
@@ -915,7 +915,7 @@ class Assertion
      */
     public static function range($value, $minValue, $maxValue, $message = null, $propertyPath = null)
     {
-        static::integer($value);
+        static::numeric($value);
 
         if ($value < $minValue || $value > $maxValue) {
             $message = $message ?: sprintf(
@@ -941,7 +941,7 @@ class Assertion
      */
     public static function min($value, $minValue, $message = null, $propertyPath = null)
     {
-        static::integer($value);
+        static::numeric($value);
 
         if ($value < $minValue) {
             $message = $message ?: sprintf(
@@ -966,7 +966,7 @@ class Assertion
      */
     public static function max($value, $maxValue, $message = null, $propertyPath = null)
     {
-        static::integer($value);
+        static::numeric($value);
 
         if ($value > $maxValue) {
             $message = $message ?: sprintf(

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -431,6 +431,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_RANGE);
         Assertion::range(1, 2, 3);
+        Assertion::range(1.5, 2, 3);
     }
 
     public function testValidRange()
@@ -438,6 +439,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::range(1, 1, 2);
         Assertion::range(2, 1, 2);
         Assertion::range(2, 0, 100);
+        Assertion::range(2.5, 2.25, 2.75);
     }
 
     public function testInvalidEmail()
@@ -591,6 +593,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::min(1, 1);
         Assertion::min(2, 1);
+        Assertion::min(2.5, 1);
 
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MIN);
         Assertion::min(0, 1);
@@ -599,6 +602,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     public function testMax()
     {
         Assertion::max(1, 1);
+        Assertion::max(0.5, 1);
         Assertion::max(0, 1);
 
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MAX);


### PR DESCRIPTION
Currently `min()`, `max()` and `range()` all do an `integer()` check, which means that floats can't be checked. This relaxes it to `numeric()`. If the user cares about the value being an integer, it should be checked separately.

(This kind-of fixes #53, as integerish values will also be accepted.)
