### PR TITLE
Updated composer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ The library is not using Symfony or Zend Validators for a reason: The checks hav
 
 Using Composer:
 
-```javascript
-{
-    "require": {
-        "beberlei/assert": "@stable"
-    }
-}
+```sh
+composer require beberlei/assert
 ```
 
 ## Example usages


### PR DESCRIPTION
Now using the composer require command without specifying a version.

This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~2.0), updating the composer.json and running install, all in one command.
