### PR TITLE
Avoid object to throw incorrect exception for integerish

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -356,7 +356,7 @@ class Assertion
      */
     public static function integerish($value, $message = null, $propertyPath = null)
     {
-        if (strval(intval($value)) != $value || is_bool($value) || is_null($value)) {
+        if (is_object($value) || strval(intval($value)) != $value || is_bool($value) || is_null($value)) {
             $message = $message ?: sprintf(
                 'Value "%s" is not an integer or a number castable to integer.',
                 self::stringify($value)

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -43,6 +43,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
             array(null),
             array("1.23"),
             array("10"),
+            array(new \DateTime()),
         );
     }
 


### PR DESCRIPTION
Fixed a problem where intval is used for an object and this may lead to a exception from the object or a notice. According to the php manual `intval() should not be used on objects`.
