### PR TITLE
Bump minor version to 2.1.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "2.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
Since it looks like 2.1 has been released, would it make sense to bump the minor version for the dev-master alias to 2.1.x as well? If so, you might consider whether you should create a 2.0 branch as well. My guess is that is probably too much work. :)
