### PR TITLE
Passed message to sprintf() to make it parameterizable

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -206,8 +206,8 @@ class Assertion
     public static function eq($value, $value2, $message = null, $propertyPath = null)
     {
         if ($value != $value2) {
-            $message = $message ?: sprintf(
-                'Value "%s" does not equal expected value "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" does not equal expected value "%s".',
                 self::stringify($value),
                 self::stringify($value2)
             );
@@ -229,8 +229,8 @@ class Assertion
     public static function same($value, $value2, $message = null, $propertyPath = null)
     {
         if ($value !== $value2) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not the same as expected value "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not the same as expected value "%s".',
                 self::stringify($value),
                 self::stringify($value2)
             );
@@ -252,8 +252,8 @@ class Assertion
     public static function notEq($value1, $value2, $message = null, $propertyPath = null)
     {
         if ($value1 == $value2) {
-            $message = $message ?: sprintf(
-                'Value "%s" is equal to expected value "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" is equal to expected value "%s".',
                 self::stringify($value1),
                 self::stringify($value2)
             );
@@ -274,8 +274,8 @@ class Assertion
     public static function notSame($value1, $value2, $message = null, $propertyPath = null)
     {
         if ($value1 === $value2) {
-            $message = $message ?: sprintf(
-                'Value "%s" is the same as expected value "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" is the same as expected value "%s".',
                 self::stringify($value1),
                 self::stringify($value2)
             );
@@ -295,8 +295,8 @@ class Assertion
     public static function integer($value, $message = null, $propertyPath = null)
     {
         if ( ! is_int($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not an integer.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not an integer.',
                 self::stringify($value)
             );
 
@@ -316,8 +316,8 @@ class Assertion
     public static function float($value, $message = null, $propertyPath = null)
     {
         if ( ! is_float($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not a float.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not a float.',
                 self::stringify($value)
             );
 
@@ -337,8 +337,8 @@ class Assertion
     public static function digit($value, $message = null, $propertyPath = null)
     {
         if ( ! ctype_digit((string)$value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not a digit.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not a digit.',
                 self::stringify($value)
             );
 
@@ -357,8 +357,8 @@ class Assertion
     public static function integerish($value, $message = null, $propertyPath = null)
     {
         if (strval(intval($value)) != $value || is_bool($value) || is_null($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not an integer or a number castable to integer.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not an integer or a number castable to integer.',
                 self::stringify($value)
             );
 
@@ -378,8 +378,8 @@ class Assertion
     public static function boolean($value, $message = null, $propertyPath = null)
     {
         if ( ! is_bool($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not a boolean.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not a boolean.',
                 self::stringify($value)
             );
 
@@ -399,8 +399,8 @@ class Assertion
     public static function scalar($value, $message = null, $propertyPath = null)
     {
         if (!is_scalar($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not a scalar.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not a scalar.',
                 self::stringify($value)
             );
 
@@ -420,8 +420,8 @@ class Assertion
     public static function notEmpty($value, $message = null, $propertyPath = null)
     {
         if (empty($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is empty, but non empty value was expected.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is empty, but non empty value was expected.',
                 self::stringify($value)
             );
 
@@ -441,8 +441,8 @@ class Assertion
     public static function noContent($value, $message = null, $propertyPath = null)
     {
         if (!empty($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not empty, but empty value was expected.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not empty, but empty value was expected.',
                 self::stringify($value)
             );
 
@@ -462,8 +462,8 @@ class Assertion
     public static function notNull($value, $message = null, $propertyPath = null)
     {
         if ($value === null) {
-            $message = $message ?: sprintf(
-                'Value "%s" is null, but non null value was expected.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is null, but non null value was expected.',
                 self::stringify($value)
             );
 
@@ -483,8 +483,8 @@ class Assertion
     public static function string($value, $message = null, $propertyPath = null)
     {
         if ( ! is_string($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" expected to be string, type %s given.',
+            $message = sprintf(
+                $message ?: 'Value "%s" expected to be string, type %s given.',
                 self::stringify($value),
                 gettype($value)
             );
@@ -508,8 +508,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if ( ! preg_match($pattern, $value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" does not match expression.',
+            $message = sprintf(
+                $message ?: 'Value "%s" does not match expression.',
                 self::stringify($value)
             );
 
@@ -533,8 +533,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if (mb_strlen($value, $encoding) !== $length) {
-            $message = $message ?: sprintf(
-                'Value "%s" has to be %d exactly characters long, but length is %d.',
+            $message = sprintf(
+                $message ?: 'Value "%s" has to be %d exactly characters long, but length is %d.',
                 self::stringify($value),
                 $length,
                 mb_strlen($value, $encoding)
@@ -561,8 +561,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if (mb_strlen($value, $encoding) < $minLength) {
-            $message = $message ?: sprintf(
-                'Value "%s" is too short, it should have more than %d characters, but only has %d characters.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is too short, it should have more than %d characters, but only has %d characters.',
                 self::stringify($value),
                 $minLength,
                 mb_strlen($value, $encoding)
@@ -589,8 +589,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if (mb_strlen($value, $encoding) > $maxLength) {
-            $message = $message ?: sprintf(
-                'Value "%s" is too long, it should have no more than %d characters, but has %d characters.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is too long, it should have no more than %d characters, but has %d characters.',
                 self::stringify($value),
                 $maxLength,
                 mb_strlen($value, $encoding)
@@ -618,8 +618,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if (mb_strlen($value, $encoding) < $minLength) {
-            $message = $message ?: sprintf(
-                'Value "%s" is too short, it should have more than %d characters, but only has %d characters.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is too short, it should have more than %d characters, but only has %d characters.',
                 self::stringify($value),
                 $minLength,
                 mb_strlen($value, $encoding)
@@ -630,8 +630,8 @@ class Assertion
         }
 
         if (mb_strlen($value, $encoding) > $maxLength) {
-            $message = $message ?: sprintf(
-                'Value "%s" is too long, it should have no more than %d characters, but has %d characters.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is too long, it should have no more than %d characters, but has %d characters.',
                 self::stringify($value),
                 $maxLength,
                 mb_strlen($value, $encoding)
@@ -658,8 +658,8 @@ class Assertion
         static::string($string, $message, $propertyPath);
 
         if (mb_strpos($string, $needle, null, $encoding) !== 0) {
-            $message = $message ?: sprintf(
-                'Value "%s" does not start with "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" does not start with "%s".',
                 self::stringify($string),
                 self::stringify($needle)
             );
@@ -687,8 +687,8 @@ class Assertion
         $stringPosition = mb_strlen($string, $encoding) - mb_strlen($needle, $encoding);
 
         if (mb_strripos($string, $needle, null, $encoding) !== $stringPosition) {
-            $message = $message ?: sprintf(
-                'Value "%s" does not end with "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" does not end with "%s".',
                 self::stringify($string),
                 self::stringify($needle)
             );
@@ -714,8 +714,8 @@ class Assertion
         static::string($string, $message, $propertyPath);
 
         if (mb_strpos($string, $needle, null, $encoding) === false) {
-            $message = $message ?: sprintf(
-                'Value "%s" does not contain "%s".',
+            $message = sprintf(
+                $message ?: 'Value "%s" does not contain "%s".',
                 self::stringify($string),
                 self::stringify($needle)
             );
@@ -738,8 +738,8 @@ class Assertion
     public static function choice($value, array $choices, $message = null, $propertyPath = null)
     {
         if ( ! in_array($value, $choices, true)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not an element of the valid values: %s',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not an element of the valid values: %s',
                 self::stringify($value),
                 implode(", ", array_map('Assert\Assertion::stringify', $choices))
             );
@@ -770,8 +770,8 @@ class Assertion
     public static function numeric($value, $message = null, $propertyPath = null)
     {
         if ( ! is_numeric($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not numeric.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not numeric.',
                 self::stringify($value)
             );
 
@@ -791,8 +791,8 @@ class Assertion
     public static function isArray($value, $message = null, $propertyPath = null)
     {
         if ( ! is_array($value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not an array.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not an array.',
                 self::stringify($value)
             );
 
@@ -815,8 +815,8 @@ class Assertion
         static::isArray($value, $message, $propertyPath);
 
         if ( ! array_key_exists($key, $value)) {
-            $message = $message ?: sprintf(
-                'Array does not contain an element with key "%s"',
+            $message = sprintf(
+                $message ?: 'Array does not contain an element with key "%s"',
                 self::stringify($key)
             );
 
@@ -852,8 +852,8 @@ class Assertion
     public static function notBlank($value, $message = null, $propertyPath = null)
     {
         if (false === $value || (empty($value) && '0' != $value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is blank, but was expected to contain a value.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is blank, but was expected to contain a value.',
                 self::stringify($value)
             );
 
@@ -874,8 +874,8 @@ class Assertion
     public static function isInstanceOf($value, $className, $message = null, $propertyPath = null)
     {
         if ( ! ($value instanceof $className)) {
-            $message = $message ?: sprintf(
-                'Class "%s" was expected to be instanceof of "%s" but is not.',
+            $message = sprintf(
+                $message ?: 'Class "%s" was expected to be instanceof of "%s" but is not.',
                 self::stringify($value),
                 $className
             );
@@ -897,8 +897,8 @@ class Assertion
     public static function notIsInstanceOf($value, $className, $message = null, $propertyPath = null)
     {
         if ($value instanceof $className) {
-            $message = $message ?: sprintf(
-                'Class "%s" was not expected to be instanceof of "%s".',
+            $message = sprintf(
+                $message ?: 'Class "%s" was not expected to be instanceof of "%s".',
                 self::stringify($value),
                 $className
             );
@@ -920,8 +920,8 @@ class Assertion
     public static function subclassOf($value, $className, $message = null, $propertyPath = null)
     {
         if ( ! is_subclass_of($value, $className)) {
-            $message = $message ?: sprintf(
-                'Class "%s" was expected to be subclass of "%s".',
+            $message = sprintf(
+                $message ?: 'Class "%s" was expected to be subclass of "%s".',
                 self::stringify($value),
                 $className
             );
@@ -946,8 +946,8 @@ class Assertion
         static::numeric($value, $message, $propertyPath);
 
         if ($value < $minValue || $value > $maxValue) {
-            $message = $message ?: sprintf(
-                'Number "%s" was expected to be at least "%d" and at most "%d".',
+            $message = sprintf(
+                $message ?: 'Number "%s" was expected to be at least "%d" and at most "%d".',
                 self::stringify($value),
                 self::stringify($minValue),
                 self::stringify($maxValue)
@@ -972,8 +972,8 @@ class Assertion
         static::numeric($value, $message, $propertyPath);
 
         if ($value < $minValue) {
-            $message = $message ?: sprintf(
-                'Number "%s" was expected to be at least "%d".',
+            $message = sprintf(
+                $message ?: 'Number "%s" was expected to be at least "%d".',
                 self::stringify($value),
                 self::stringify($minValue)
             );
@@ -997,8 +997,8 @@ class Assertion
         static::numeric($value, $message, $propertyPath);
 
         if ($value > $maxValue) {
-            $message = $message ?: sprintf(
-                'Number "%s" was expected to be at most "%d".',
+            $message = sprintf(
+                $message ?: 'Number "%s" was expected to be at most "%d".',
                 self::stringify($value),
                 self::stringify($maxValue)
             );
@@ -1022,8 +1022,8 @@ class Assertion
         static::notEmpty($value, $message, $propertyPath);
 
         if ( ! is_file($value)) {
-            $message = $message ?: sprintf(
-                'File "%s" was expected to exist.',
+            $message = sprintf(
+                $message ?: 'File "%s" was expected to exist.',
                 self::stringify($value)
             );
 
@@ -1045,8 +1045,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if ( ! is_dir($value)) {
-            $message = $message ?: sprintf(
-                'Path "%s" was expected to be a directory.',
+            $message = sprintf(
+                $message ?: 'Path "%s" was expected to be a directory.',
                 self::stringify($value)
             );
 
@@ -1068,8 +1068,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if ( ! is_readable($value)) {
-            $message = $message ?: sprintf(
-                'Path "%s" was expected to be readable.',
+            $message = sprintf(
+                $message ?: 'Path "%s" was expected to be readable.',
                 self::stringify($value)
             );
 
@@ -1091,8 +1091,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if ( ! is_writeable($value)) {
-            $message = $message ?: sprintf(
-                'Path "%s" was expected to be writeable.',
+            $message = sprintf(
+                $message ?: 'Path "%s" was expected to be writeable.',
                 self::stringify($value)
             );
 
@@ -1115,8 +1115,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
 
         if ( ! filter_var($value, FILTER_VALIDATE_EMAIL)) {
-            $message = $message ?: sprintf(
-                'Value "%s" was expected to be a valid e-mail address.',
+            $message = sprintf(
+                $message ?: 'Value "%s" was expected to be a valid e-mail address.',
                 self::stringify($value)
             );
 
@@ -1126,8 +1126,8 @@ class Assertion
 
             // Likely not a FQDN, bug in PHP FILTER_VALIDATE_EMAIL prior to PHP 5.3.3
             if (version_compare(PHP_VERSION, '5.3.3', '<') && strpos($host, '.') === false) {
-                $message = $message ?: sprintf(
-                    'Value "%s" was expected to be a valid e-mail address.',
+                $message = sprintf(
+                    $message ?: 'Value "%s" was expected to be a valid e-mail address.',
                     self::stringify($value)
                 );
 
@@ -1175,8 +1175,8 @@ class Assertion
         $pattern = sprintf($pattern, implode('|', $protocols));
 
         if (!preg_match($pattern, $value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" was expected to be a valid URL starting with http or https',
+            $message = sprintf(
+                $message ?: 'Value "%s" was expected to be a valid URL starting with http or https',
                 self::stringify($value)
             );
 
@@ -1199,8 +1199,8 @@ class Assertion
         try {
             static::regex($value, '(^([a-zA-Z]{1}[a-zA-Z0-9]*)$)', $message, $propertyPath);
         } catch(AssertionFailedException $e) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not alphanumeric, starting with letters and containing only letters and numbers.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not alphanumeric, starting with letters and containing only letters and numbers.',
                 self::stringify($value)
             );
 
@@ -1220,8 +1220,8 @@ class Assertion
     public static function true($value, $message = null, $propertyPath = null)
     {
         if ($value !== true) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not TRUE.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not TRUE.',
                 self::stringify($value)
             );
 
@@ -1241,8 +1241,8 @@ class Assertion
     public static function false($value, $message = null, $propertyPath = null)
     {
         if ($value !== false) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not FALSE.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not FALSE.',
                 self::stringify($value)
             );
 
@@ -1262,8 +1262,8 @@ class Assertion
     public static function classExists($value, $message = null, $propertyPath = null)
     {
         if ( ! class_exists($value)) {
-            $message = $message ?: sprintf(
-                'Class "%s" does not exist.',
+            $message = sprintf(
+                $message ?: 'Class "%s" does not exist.',
                 self::stringify($value)
             );
 
@@ -1285,8 +1285,8 @@ class Assertion
     {
         $reflection = new \ReflectionClass($class);
         if ( ! $reflection->implementsInterface($interfaceName)) {
-            $message = $message ?: sprintf(
-                'Class "%s" does not implement interface "%s".',
+            $message = sprintf(
+                $message ?: 'Class "%s" does not implement interface "%s".',
                 self::stringify($class),
                 self::stringify($interfaceName)
             );
@@ -1313,8 +1313,8 @@ class Assertion
     public static function isJsonString($value, $message = null, $propertyPath = null)
     {
         if (null === json_decode($value) && JSON_ERROR_NONE !== json_last_error()) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not a valid JSON string.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not a valid JSON string.',
                 self::stringify($value)
             );
 
@@ -1342,8 +1342,8 @@ class Assertion
         }
 
         if (!preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', $value)) {
-            $message = $message ?: sprintf(
-                'Value "%s" is not a valid UUID.',
+            $message = sprintf(
+                $message ?: 'Value "%s" is not a valid UUID.',
                 self::stringify($value)
             );
 
@@ -1364,8 +1364,8 @@ class Assertion
     public static function count($countable, $count, $message = null, $propertyPath = null)
     {
         if ($count !== count($countable)) {
-            $message = $message ?: sprintf(
-                'List does not contain exactly "%d" elements.',
+            $message = sprintf(
+                $message ?: 'List does not contain exactly "%d" elements.',
                 self::stringify($countable),
                 self::stringify($count)
             );
@@ -1449,8 +1449,8 @@ class Assertion
         self::isObject($object, $message, $propertyPath);
 
         if (!method_exists($object, $value)) {
-            $message = $message ?: sprintf(
-                'Expected "%s" does not a exist in provided object.',
+            $message = sprintf(
+                $message ?: 'Expected "%s" does not a exist in provided object.',
                 self::stringify($value)
             );
 
@@ -1468,8 +1468,8 @@ class Assertion
     public static function isObject($value, $message = null, $propertyPath = null)
     {
         if (!is_object($value)) {
-            $message = $message ?: sprintf(
-                'Provided "%s" is not a valid object.',
+            $message = sprintf(
+                $message ?: 'Provided "%s" is not a valid object.',
                 self::stringify($value)
             );
 


### PR DESCRIPTION
Fixes #16

Parameter's can be selected with sprintf()'s position specifier:

``` php
Assertion::string(1234, 'Path should be a string. Got: %2$s');
```

Outputs:

Path should be a string. Got: integer
