### PR TITLE
Show fractional parts of $minValue and $maxValue in error messages.

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1123,7 +1123,7 @@ class Assertion
 
         if ($value < $minValue) {
             $message = sprintf(
-                $message ?: 'Number "%s" was expected to be at least "%d".',
+                $message ?: 'Number "%s" was expected to be at least "%s".',
                 static::stringify($value),
                 static::stringify($minValue)
             );
@@ -1148,7 +1148,7 @@ class Assertion
 
         if ($value > $maxValue) {
             $message = sprintf(
-                $message ?: 'Number "%s" was expected to be at most "%d".',
+                $message ?: 'Number "%s" was expected to be at most "%s".',
                 static::stringify($value),
                 static::stringify($maxValue)
             );

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -647,8 +647,21 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::min(2, 1);
         Assertion::min(2.5, 1);
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MIN);
-        Assertion::min(0, 1);
+        try {
+            Assertion::min(0, 1);
+            $this->fail('Expected exception `Assert\AssertionFailedException` not thrown');
+        } catch (AssertionFailedException $e){
+            $this->assertEquals(Assertion::INVALID_MIN, $e->getCode());
+            $this->assertEquals('Number "0" was expected to be at least "1".', $e->getMessage());
+        }
+
+        try {
+            Assertion::min(0.5, 2.5);
+            $this->fail('Expected exception `Assert\AssertionFailedException` not thrown');
+        } catch (AssertionFailedException $e){
+            $this->assertEquals(Assertion::INVALID_MIN, $e->getCode());
+            $this->assertEquals('Number "0.5" was expected to be at least "2.5".', $e->getMessage());
+        }
     }
 
     public function testMax()
@@ -657,8 +670,21 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::max(0.5, 1);
         Assertion::max(0, 1);
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MAX);
-        Assertion::max(2, 1);
+        try {
+            Assertion::max(2, 1);
+            $this->fail('Expected exception `Assert\AssertionFailedException` not thrown');
+        } catch (AssertionFailedException $e){
+            $this->assertEquals(Assertion::INVALID_MAX, $e->getCode());
+            $this->assertEquals('Number "2" was expected to be at most "1".', $e->getMessage());
+        }
+
+        try {
+            Assertion::max(2.5, 0.5);
+            $this->fail('Expected exception `Assert\AssertionFailedException` not thrown');
+        } catch (AssertionFailedException $e){
+            $this->assertEquals(Assertion::INVALID_MAX, $e->getCode());
+            $this->assertEquals('Number "2.5" was expected to be at most "0.5".', $e->getMessage());
+        }
     }
 
     public function testNullOr()


### PR DESCRIPTION
Specify $minValue and $maxValue as a string value in the error message.

The fractional part is not visible in the error message of the following
methods:

Assert\Assertion::min(0.1, 0.2);
Assert\InvalidArgumentException with message 'Number "0.1" was expected
to be at least "0".'

Should be: Number "0.1" was expected to be at least "0.2".

Assert\Assertion::max(0.2, 0.1);
Assert\InvalidArgumentException with message 'Number "0.2" was expected
to be at most "0".'

Should be: Number "0.2" was expected to be at most "0.1".