### PR TITLE
Assert booleanish PHP values

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -30,6 +30,7 @@ use BadMethodCallException;
  * @method static void nullOrDigit($value, $message = null, $propertyPath = null)
  * @method static void nullOrIntegerish($value, $message = null, $propertyPath = null)
  * @method static void nullOrBoolean($value, $message = null, $propertyPath = null)
+ * @method static void nullOrBooleanish($value, $message = null, $propertyPath = null)
  * @method static void nullOrScalar($value, $message = null, $propertyPath = null)
  * @method static void nullOrNotEmpty($value, $message = null, $propertyPath = null)
  * @method static void nullOrNoContent($value, $message = null, $propertyPath = null)
@@ -85,6 +86,7 @@ use BadMethodCallException;
  * @method static void allDigit($value, $message = null, $propertyPath = null)
  * @method static void allIntegerish($value, $message = null, $propertyPath = null)
  * @method static void allBoolean($value, $message = null, $propertyPath = null)
+ * @method static void allBooleanish($value, $message = null, $propertyPath = null)
  * @method static void allScalar($value, $message = null, $propertyPath = null)
  * @method static void allNotEmpty($value, $message = null, $propertyPath = null)
  * @method static void allNoContent($value, $message = null, $propertyPath = null)
@@ -190,6 +192,7 @@ class Assertion
     const INVALID_LESS_OR_EQUAL     = 211;
     const INVALID_GREATER           = 212;
     const INVALID_GREATER_OR_EQUAL  = 212;
+    const INVALID_BOOLEANISH        = 213;
 
     /**
      * Exception to throw when an assertion failed.
@@ -400,6 +403,31 @@ class Assertion
             );
 
             throw static::createException($value, $message, static::INVALID_BOOLEAN, $propertyPath);
+        }
+    }
+
+    /**
+     * Assert that value is a php boolean'ish.
+     * @param mixed $value
+     * @param string|null $message
+     * @param string|null $propertyPath
+     * @return void
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function booleanish($value, $message = null, $propertyPath = null)
+    {
+        // protect against https://bugs.php.net/bug.php?id=49510
+        if (false === $value || null === $value) {
+            return;
+        }
+
+        if (null === filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+            $message = sprintf(
+                $message ?: 'Value "%s" is not boolean or 1 or 0.',
+                self::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_BOOLEANISH, $propertyPath);
         }
     }
 

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -31,6 +31,7 @@ use ReflectionClass;
  * @method \Assert\AssertionChain digit($message = null, $propertyPath = null)
  * @method \Assert\AssertionChain integerish($message = null, $propertyPath = null)
  * @method \Assert\AssertionChain boolean($message = null, $propertyPath = null)
+ * @method \Assert\AssertionChain booleanish($message = null, $propertyPath = null)
  * @method \Assert\AssertionChain scalar($message = null, $propertyPath = null)
  * @method \Assert\AssertionChain notEmpty($message = null, $propertyPath = null)
  * @method \Assert\AssertionChain noContent($message = null, $propertyPath = null)

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -28,6 +28,7 @@ namespace Assert;
  * @method \Assert\LazyAssertion digit($message = null, $propertyPath = null)
  * @method \Assert\LazyAssertion integerish($message = null, $propertyPath = null)
  * @method \Assert\LazyAssertion boolean($message = null, $propertyPath = null)
+ * @method \Assert\LazyAssertion booleanish($message = null, $propertyPath = null)
  * @method \Assert\LazyAssertion scalar($message = null, $propertyPath = null)
  * @method \Assert\LazyAssertion notEmpty($message = null, $propertyPath = null)
  * @method \Assert\LazyAssertion noContent($message = null, $propertyPath = null)

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -100,11 +100,44 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::boolean(1);
     }
 
+    public function testValidBooleanish()
+    {
+        Assertion::booleanish(true);
+        Assertion::booleanish(false);
+        Assertion::booleanish(1);
+        Assertion::booleanish(0);
+        Assertion::booleanish(null);
+        Assertion::booleanish('1');
+        Assertion::booleanish('0');
+    }
+
+    public static function dataInvalidBooleanish()
+    {
+        return array(
+            array(-1),
+            array(2),
+            array('2'),
+            array('string'),
+            array(1.23),
+            array("1.23"),
+        );
+    }
+
+    /**
+     * @dataProvider dataInvalidBooleanish
+     */
+    public function testInvalidBooleanish($nonBoolean)
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_BOOLEANISH);
+        Assertion::booleanish($nonBoolean);
+    }
+
     public function testInvalidScalar()
     {
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_SCALAR);
         Assertion::scalar(new \stdClass);
     }
+
 
     public function testValidScalar()
     {


### PR DESCRIPTION
The integerish assertion has been incredibly useful in our validation. This does the same for "booleanish" values.