### PR TITLE
Custom assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,38 @@ use Assert\Assertion as BaseAssertion;
 class Assertion extends BaseAssertion
 {
     protected static $exceptionClass = 'MyProject\AssertionFailedException';
+
+    const INVALID_CUSTOM = 10001;
+
+    /**
+      * You can also create your own assertion methods
+      *
+      * Be aware, these methods will only be available when using a custom assertion chain
+      */
+    public static function customAssert($value, $message = null, $propertyPath = null)
+    {
+        if (!$value) {
+            $message = sprintf(
+                $message ?: 'Value "%s" doesn\'t pass.',
+                self::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_CUSTOM, $propertyPath);
+        }
+    }
 }
 ```
 
+To get access to these assertion methods when chaining, you'll need to create your own assertion chain subclass.
+
+
+```php
+namespace MyProject;
+
+use Assert\AssertionChain as BaseChain;
+
+class AssertionChain extends BaseChain
+{
+    protected $assertionClass = 'MyProject\Assertion';
+}
+```

--- a/README.md
+++ b/README.md
@@ -280,3 +280,17 @@ class LazyAssertion extends BaseLazy
     protected $assertChainClass = 'MyProject\AssertionChain';
 }
 ```
+
+### Custom assertions and \Assert\that()
+
+You will not be able to use your custom assertion methods if you use \Assert\that() and similar functions.  One solution to this is to copy the functions into your project/library under your namespace.
+
+```php
+namespace MyProject;
+
+function that($value, $defaultMessage = null, $defaultPropertyPath = null)
+{
+    return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+}
+```
+`\MyProject\that($value)` will return an instance of your custom assertion chain with full access to your custom assertion methods

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ class Assertion extends BaseAssertion
 }
 ```
 
-To get access to these assertion methods when chaining, you'll need to create your own assertion chain subclass.
+To get access to custom assertion methods when chaining, you'll need to create your own assertion chain subclass.
 
 
 ```php
@@ -265,5 +265,18 @@ use Assert\AssertionChain as BaseChain;
 class AssertionChain extends BaseChain
 {
     protected $assertionClass = 'MyProject\Assertion';
+}
+```
+
+To get access to custom assertion methods when using a lazy assertion, you'll need to create your own lazy assertion subclass.
+
+```php
+namespace MyProject;
+
+use Assert\LazyAssertion as BaseLazy;
+
+class LazyAssertion extends BaseLazy
+{
+    protected $assertChainClass = 'MyProject\AssertionChain';
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
         },
         "files": ["lib/Assert/functions.php"]
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Assert\\Tests\\": "tests/Assert/Tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.3-dev"

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -100,6 +100,8 @@ class AssertionChain
      */
     private $all = false;
 
+    protected $assertionClass = 'Assert\Assertion';
+
     public function __construct($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
         $this->value = $value;
@@ -121,11 +123,11 @@ class AssertionChain
             return $this;
         }
 
-        if (!method_exists('Assert\Assertion', $methodName)) {
+        if (!method_exists($this->assertionClass, $methodName)) {
             throw new \RuntimeException("Assertion '" . $methodName . "' does not exist.");
         }
 
-        $reflClass = new ReflectionClass('Assert\Assertion');
+        $reflClass = new ReflectionClass($this->assertionClass);
         $method = $reflClass->getMethod($methodName);
 
         array_unshift($args, $this->value);
@@ -149,7 +151,7 @@ class AssertionChain
             $methodName = 'all' . $methodName;
         }
 
-        call_user_func_array(array('Assert\Assertion', $methodName), $args);
+        call_user_func_array(array($this->assertionClass, $methodName), $args);
 
         return $this;
     }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -81,10 +81,12 @@ class LazyAssertion
     private $currentChain;
     private $errors = array();
 
+    protected $assertChainClass = 'Assert\AssertionChain';
+
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
-        $this->currentChain = \Assert\that($value, $defaultMessage, $propertyPath);
+        $this->currentChain = new $this->assertChainClass($value, $defaultMessage, $propertyPath);
 
         return $this;
     }

--- a/tests/Assert/Tests/CustomAssertion.php
+++ b/tests/Assert/Tests/CustomAssertion.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Assert\Tests;
+
+use Assert\Assertion;
+
+class CustomAssertion extends Assertion
+{
+    const INVALID_CUSTOM = 10001;
+
+    public static function customAssert($value, $message = null, $propertyPath = null)
+    {
+        if (!$value) {
+            $message = sprintf(
+                $message ?: 'Value "%s" doesn\'t pass.',
+                self::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_CUSTOM, $propertyPath);
+        }
+    }
+}

--- a/tests/Assert/Tests/CustomAssertionChain.php
+++ b/tests/Assert/Tests/CustomAssertionChain.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Assert\Tests;
+
+use Assert\AssertionChain;
+
+class CustomAssertionChain extends AssertionChain
+{
+    protected $assertionClass = 'Assert\Tests\CustomAssertion';
+}

--- a/tests/Assert/Tests/CustomAssertionChainTest.php
+++ b/tests/Assert/Tests/CustomAssertionChainTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+class CustomAssertionChainTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAnAssertionChain()
+    {
+        $this->assertInstanceOf('Assert\AssertionChain', new CustomAssertionChain(10));
+    }
+
+    public function testHasAccessToMethodsInCustomAssert()
+    {
+        $chain = new CustomAssertionChain(true);
+        $chain->customAssert();
+    }
+
+    public function testHasAccessToMethodsInLibAssert()
+    {
+        $chain = new CustomAssertionChain(true);
+        $chain->boolean();
+    }
+
+    public function testCanThrowErrors()
+    {
+        $this->setExpectedException('Assert\InvalidArgumentException', null, CustomAssertion::INVALID_CUSTOM);
+        $chain = new CustomAssertionChain(false);
+        $chain->customAssert();
+    }
+}


### PR DESCRIPTION
Provides a lot of hooks for people who want to be able to add their own assertions but don't want to lose the power of chaining and fluent interfaces.
Having to recreate the that*() functions isn't ideal, but if someone is keen enough in their desire for custom assertions then it's a pretty small overhead.