### PR TITLE
Treat spaces as blank

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -929,7 +929,7 @@ class Assertion
      */
     public static function notBlank($value, $message = null, $propertyPath = null)
     {
-        if (false === $value || (empty($value) && '0' != $value)) {
+        if (false === $value || (empty($value) && '0' != $value) || (is_string($value) && '' === trim($value))) {
             $message = sprintf(
                 $message ?: 'Value "%s" is blank, but was expected to contain a value.',
                 self::stringify($value)

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -398,10 +398,27 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::keyExists(array("foo" => "bar"), "foo");
     }
 
-    public function testInvalidNotBlank()
+    public static function dataInvalidNotBlank()
+    {
+        return array(
+            array(""),
+            array(" "),
+            array("\t"),
+            array("\n"),
+            array("\r"),
+            array(false),
+            array(null),
+            array( array() ),
+        );
+    }
+
+    /**
+     * @dataProvider dataInvalidNotBlank
+     */
+    public function testInvalidNotBlank($notBlank)
     {
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_NOT_BLANK);
-        Assertion::notBlank("");
+        Assertion::notBlank($notBlank);
     }
 
     public function testValidNotBlank()


### PR DESCRIPTION
Currently `Assertion::notBlank()` passes if the value is only spaces (tabs, new lines etc), this changes it so that it checks if the `trim`-med value is empty.