### PR TITLE
Declare minimum required PHP Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "BSD-2-Clause",
     "keywords": ["assert", "assertion", "validation"],
     "require": {
+        "php": ">=5.3",
         "ext-mbstring": "*"
     },
     "autoload": {


### PR DESCRIPTION
I was unable to find any hint on the minimum required PHP Version.
The Travis-CI tests are running on minimum 5.3 so I declared it in the composer.json file to make it more discoverable.