### PR TITLE
[Feature][Refactoring] Will add min/max count

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -193,6 +193,7 @@ class Assertion
     const INVALID_GREATER           = 212;
     const INVALID_GREATER_OR_EQUAL  = 212;
     const INVALID_DATE              = 213;
+    const INVALID_NOT_COUNTABLE     = 214;
 
     /**
      * Exception to throw when an assertion failed.
@@ -1437,24 +1438,92 @@ class Assertion
     }
 
     /**
-     * Assert that the count of countable is equal to count.
+     * Assert that the value is countable.
      *
-     * @param array|\Countable $countable
-     * @param int              $count
+     * @param mixed            $value
      * @param string           $message
      * @param string           $propertyPath
      * @return void
      * @throws \Assert\AssertionFailedException
      */
-    public static function count($countable, $count, $message = null, $propertyPath = null)
+    public static function countable($value, $message = null, $propertyPath = null)
     {
-        if ($count !== count($countable)) {
+        if (!$value instanceof \Countable && !is_array($value)) {
+            $message = 'Provided value is not countable';
+            throw static::createException($value, $message, static::INVALID_NOT_COUNTABLE, $propertyPath);
+        }
+
+    }
+
+    /**
+     * Assert that the value is countable and his size matches the given integer.
+     *
+     * @param mixed            $value
+     * @param int              $size expected countable size
+     * @param string           $message
+     * @param string           $propertyPath
+     * @return void
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function count($value, $size, $message = null, $propertyPath = null)
+    {
+        static::countable($value,$message,$propertyPath);
+
+        if ($size !== count($value)) {
             $message = sprintf(
                 $message ?: 'List does not contain exactly "%d" elements.',
-                self::stringify($count)
+                self::stringify($size)
             );
 
-            throw static::createException($countable, $message, static::INVALID_COUNT, $propertyPath, array('count' => $count));
+            throw static::createException($value, $message, static::INVALID_COUNT, $propertyPath, array('count' => $size));
+        }
+    }
+
+    /**
+     * Assert that the value is countable and his size matches the given integer.
+     *
+     * @param mixed            $value
+     * @param int              $min minimum elements expected
+     * @param string           $message
+     * @param string           $propertyPath
+     * @return void
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function minCount($value, $min, $message = null, $propertyPath = null)
+    {
+        static::countable($value,$message,$propertyPath);
+
+        if (count($value) < $min) {
+            $message = sprintf(
+                $message ?: 'List contains fewer than "%d" elements.',
+                self::stringify($min)
+            );
+
+            throw static::createException($value, $message, static::INVALID_COUNT, $propertyPath, array('min' => $min));
+        }
+    }
+
+    /**
+     * Assert that the value is countable and his size matches the given integer.
+     *
+     * @param mixed            $value
+     * @param int              $max maximum elements expected
+     * @param string           $message
+     * @param string           $propertyPath
+     * @return void
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function maxCount($value, $max, $message = null, $propertyPath = null)
+    {
+        static::countable($value,$message,$propertyPath);
+
+        if (count($value) > $max) {
+            $message = sprintf(
+                $message ?: 'List contains more than "%d" elements.',
+                self::stringify($max)
+            );
+
+            throw static::createException($value, $message, static::INVALID_COUNT, $propertyPath, array('max' => $max));
         }
     }
 

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -898,29 +898,6 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::allTrue();
     }
 
-    public function testValidCount()
-    {
-        Assertion::count(array('Hi'), 1);
-        Assertion::count(new OneCountable(), 1);
-    }
-
-    public static function dataInvalidCount()
-    {
-        return array(
-            array(array('Hi', 'There'), 3),
-            array(new OneCountable(), 2),
-        );
-    }
-
-    /**
-     * @dataProvider dataInvalidCount
-     */
-    public function testInvalidCount($countable, $count)
-    {
-        $this->setExpectedException('Assert\AssertionFailedException', 'List does not contain exactly "'.$count.'" elements.', Assertion::INVALID_COUNT);
-        Assertion::count($countable, $count);
-    }
-
     public function testChoicesNotEmpty()
     {
         Assertion::choicesNotEmpty(
@@ -1142,10 +1119,5 @@ class ChildStdClass extends \stdClass
 
 }
 
-class OneCountable implements \Countable
-{
-    public function count()
-    {
-        return 1;
-    }
-}
+
+

--- a/tests/Assert/Tests/CountTest.php
+++ b/tests/Assert/Tests/CountTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+use Assert\Assertion;
+
+/**
+ * Class CountTest
+ */
+class CountTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function count_will_return_void_if_the_count_matches_the_size()
+    {
+        Assertion::count(array('Hi'), 1);
+        Assertion::count(new GenericCountable(1), 1);
+    }
+
+    /**
+     * @test
+     */
+    public static function count_will_throw_an_exception_if_the_count_does_not_match_the_size()
+    {
+        return array(
+            array(array('Hi', 'There'), 3),
+            array(new GenericCountable(1), 2),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function countable_will_throw_an_exception_if_value_is_not_countable()
+    {
+
+        $value = 'Not a countable value';
+
+        $this->setExpectedException('Assert\InvalidArgumentException',null,Assertion::INVALID_NOT_COUNTABLE);
+
+        Assertion::countable($value);
+
+    }
+
+    /**
+     * @test
+     * @dataProvider provider_for_minCount_ok
+     */
+    public function minCount_will_return_void_if_the_count_is_greater_than_or_equal_the_provided_size($value,$size)
+    {
+        Assertion::minCount($value, $size);
+    }
+
+    /**
+     * @test
+     * @dataProvider provider_for_minCount_ko
+     */
+    public function minCount_will_throw_an_exception_if_count_is_lower_than_the_provided_size($value,$size)
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_COUNT);
+        Assertion::minCount($value, $size);
+
+    }
+
+    /**
+     * @test
+     * @dataProvider provider_for_maxCount_ok
+     */
+    public function maxCount_will_return_void_if_the_count_is_lower_than_or_equal_the_provided_size($value,$size)
+    {
+        Assertion::maxCount($value, $size);
+    }
+
+    /**
+     * @test
+     * @dataProvider provider_for_maxCount_ko
+     */
+    public function maxCount_will_throw_an_exception_if_count_is_greater_than_the_provided_size($value,$size)
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_COUNT);
+        Assertion::maxCount($value, $size);
+
+    }
+    /**
+     * @dataProvider dataInvalidCount
+     */
+    public function testInvalidCount($countable, $count)
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', 'List does not contain exactly "'.$count.'" elements.', Assertion::INVALID_COUNT);
+        Assertion::count($countable, $count);
+    }
+
+
+    public static function dataInvalidCount()
+    {
+        return array(
+            array(array('Hi', 'There'), 3),
+            array(new GenericCountable(1), 2),
+        );
+    }
+
+
+    public function provider_for_minCount_ok()
+    {
+        return array(
+            array(array('Hi', 'There'), 1),
+            array(array('Hi', 'There'), 2),
+            array(new GenericCountable(2), 1),
+            array(new GenericCountable(2), 2),
+        );
+
+    }
+
+    public function provider_for_minCount_ko()
+    {
+        return array(
+            array(array('Hi', 'There'), 3),
+            array(new GenericCountable(2), 3),
+        );
+
+    }
+
+    public function provider_for_maxCount_ok()
+    {
+        return array(
+            array(array('Hi', 'There'), 3),
+            array(array('Hi', 'There'), 2),
+            array(new GenericCountable(2), 3),
+            array(new GenericCountable(2), 2),
+        );
+
+    }
+
+    public function provider_for_maxCount_ko()
+    {
+        return array(
+            array(array('Hi', 'There'), 1),
+            array(new GenericCountable(2), 1),
+        );
+
+    }
+
+}
+
+class GenericCountable implements \Countable
+{
+
+    /** @var int  */
+    protected $size;
+
+    /**
+     * @param int $size
+     */
+    public function __construct($size = 0)
+    {
+        $this->size = $size;
+
+    }
+
+    public function count()
+    {
+        return $this->size;
+    }
+}


### PR DESCRIPTION
While using the assertion library i noticed a feature gap in the count assertion logic. Basically this pr will add minCount($value, $min, ...) and maxCount($value, $max, ...). 
The current count assertion has been refactored to include a further logic check on his actual 'countability'.

Commit changes:
- New assertion countable. It will check if the provided value can be counted (\Countable or array).
- New assertion minCount.
- New assertion maxCount.
- Trivial refactoring of count assertion.
- Tests for the new assertions.

regards,
Francesco.
