### PR TITLE
Remove constructor signature from the AssertionFailedException

### DIFF
--- a/lib/Assert/AssertionFailedException.php
+++ b/lib/Assert/AssertionFailedException.php
@@ -15,7 +15,6 @@ namespace Assert;
 
 interface AssertionFailedException
 {
-    public function __construct($message, $code, $propertyPath = null, $value, array $constraints = array());
     public function getPropertyPath();
     public function getValue();
     public function getConstraints();


### PR DESCRIPTION
I think this requirement makes no sense. Interface shouldn't care about constructor signature. If you have own custom exception class with different constructor (with custom `Assertion::createException`), you wouldn't be able to implement this interface.