### PR TITLE
Only declare functions if they do not exist yet. Resolves #138

### DIFF
--- a/lib/Assert/functions.php
+++ b/lib/Assert/functions.php
@@ -13,58 +13,65 @@
 
 namespace Assert;
 
-/**
- * Start validation on a value, returns {@link AssertionChain}
- *
- * The invocation of this method starts an assertion chain
- * that is happening on the passed value.
- *
- * @example
- *
- *  \Assert\that($value)->notEmpty()->integer();
- *  \Assert\that($value)->nullOr()->string()->startsWith("Foo");
- *
- * The assertion chain can be stateful, that means be careful when you reuse
- * it. You should never pass around the chain.
- *
- * @param mixed $value
- * @param string $defaultMessage
- * @param string $defaultPropertyPath
- *
- * @return \Assert\AssertionChain
- */
-function that($value, $defaultMessage = null, $defaultPropertyPath = null)
-{
-    return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+if ( ! function_exists(__NAMESPACE__ . '\that')) {
+	/**
+	 * Start validation on a value, returns {@link AssertionChain}
+	 *
+	 * The invocation of this method starts an assertion chain
+	 * that is happening on the passed value.
+	 *
+	 * @example
+	 *
+	 *  \Assert\that($value)->notEmpty()->integer();
+	 *  \Assert\that($value)->nullOr()->string()->startsWith("Foo");
+	 *
+	 * The assertion chain can be stateful, that means be careful when you reuse
+	 * it. You should never pass around the chain.
+	 *
+	 * @param mixed $value
+	 * @param string $defaultMessage
+	 * @param string $defaultPropertyPath
+	 *
+	 * @return \Assert\AssertionChain
+	 */
+	function that($value, $defaultMessage = null, $defaultPropertyPath = null)
+	{
+	    return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+	}
 }
 
-/**
- * Start validation on a set of values, returns {@link AssertionChain}
- *
- * @return \Assert\AssertionChain
- */
-function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
-{
-    return that($values, $defaultMessage, $defaultPropertyPath)->all();
+if ( ! function_exists(__NAMESPACE__ . '\thatAll')) {
+	/**
+	 * Start validation on a set of values, returns {@link AssertionChain}
+	 *
+	 * @return \Assert\AssertionChain
+	 */
+	function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
+	{
+	    return that($values, $defaultMessage, $defaultPropertyPath)->all();
+	}
 }
 
-/**
- * Start validation and allow NULL, returns {@link AssertionChain}
- *
- * @return \Assert\AssertionChain
- */
-function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
-{
-    return that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
+if ( ! function_exists(__NAMESPACE__ . '\thatNullOr')) {
+	/**
+	 * Start validation and allow NULL, returns {@link AssertionChain}
+	 *
+	 * @return \Assert\AssertionChain
+	 */
+	function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
+	{
+	    return that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
+	}
 }
 
-/**
- * Create a lazy assertion object.
- *
- * @return \Assert\LazyAssertion
- */
-function lazy()
-{
-    return new LazyAssertion();
+if ( ! function_exists(__NAMESPACE__ . '\lazy')) {
+	/**
+	 * Create a lazy assertion object.
+	 *
+	 * @return \Assert\LazyAssertion
+	 */
+	function lazy()
+	{
+	    return new LazyAssertion();
+	}
 }
-


### PR DESCRIPTION
Files that are loaded through the Composer autoloader `files` mechanism (https://getcomposer.org/doc/04-schema.md#files) are always loaded, even if they have already been loaded by another package.

This PR adds checks so that the functions in `functions.php` only get declared if they do not exist yet, to avoid a fatal error when the `beberlei/assert` package gets pulled in more than once.

This resolves issue #138.