### PR TITLE
Speed up builds.

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,10 @@ $rules = array(
     '@PSR2' => true,
 );
 
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
 return PhpCsFixer\Config::create()
     ->setRules($rules)
     ->finder($finder)
-    ->setUsingCache(true);
+    ->setUsingCache(true)
+    ->setCacheFile($cacheDir . '/.php_cs.cache');

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,37 @@
 language: php
 
-env:
-  - OPCODE_CACHE=apc
+git:
+  depth: 2
 
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+env:
+  global:
+    - OPCODE_CACHE=apc
+
+matrix:
+  include:
+    - php: hhvm
+    - php: nightly
+    - php: 7.1
+    - php: 7.0
+      env:
+      - DISABLE_XDEBUG=true
+      - LINT=true
+    - php: 5.6
+      env:
+      - DISABLE_XDEBUG=true
+    - php: 5.5
+      env:
+      - DISABLE_XDEBUG=true
+    - php: 5.4
+      env:
+      - DISABLE_XDEBUG=true
+    - php: 5.3
+      env:
+      - DISABLE_XDEBUG=true
+
+  fast_finish: true
+  allow_failures:
+    - php: nightly
 
 cache:
   directories:
@@ -20,9 +42,13 @@ install:
   - composer update
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $DISABLE_XDEBUG = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
 
 script:
-  - composer assert:cs-lint
+  - if [[ $LINT = true ]]; then
+      composer assert:cs-lint;
+      ./bin/travis/lint-docs;
+    fi
   - php vendor/bin/phpunit
-  - composer assert:generate-docs && [[ -z $(git status -s) ]] || echo "Please run composer assert:generate-docs and commit the changes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,16 @@ php:
   - 7.0
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.php-cs-fixer
+
 install:
   - composer update
+
+before_script:
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
 
 script:
   - composer assert:cs-lint

--- a/bin/travis/lint-docs
+++ b/bin/travis/lint-docs
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+composer assert:generate-docs
+UNCOMMITED_FILES=$(git status -s | wc -l)
+if [[ $UNCOMMITED_FILES -ne 0 ]]; then
+  echo "Please run composer assert:generate-docs and commit the changes";
+  exit 1;
+fi


### PR DESCRIPTION
Disables Xdebug. Should be re-enabled when measuring code coverage is required.