### PR TITLE
Add satisfy() assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Assertion::range($value, $minValue, $maxValue);
 Assertion::readable($value);
 Assertion::regex($value, $pattern);
 Assertion::same($value, $value2);
+Assertion::satisfy($value, $callback);
 Assertion::scalar($value);
 Assertion::startsWith($string, $needle);
 Assertion::string($value);

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -75,6 +75,7 @@ use BadMethodCallException;
  * @method static void allReadable($value, $message = null, $propertyPath = null) Assert that the value is something readable for all values.
  * @method static void allRegex($value, $pattern, $message = null, $propertyPath = null) Assert that value matches a regex for all values.
  * @method static void allSame($value, $value2, $message = null, $propertyPath = null) Assert that two values are the same (using ===) for all values.
+ * @method static void allSatisfy($value, $callback, $message = null, $propertyPath = null) Assert that the provided value is valid according to a callback for all values.
  * @method static void allScalar($value, $message = null, $propertyPath = null) Assert that value is a PHP scalar for all values.
  * @method static void allStartsWith($string, $needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string starts with a sequence of chars for all values.
  * @method static void allString($value, $message = null, $propertyPath = null) Assert that value is a string for all values.
@@ -138,6 +139,7 @@ use BadMethodCallException;
  * @method static void nullOrReadable($value, $message = null, $propertyPath = null) Assert that the value is something readable or that the value is null.
  * @method static void nullOrRegex($value, $pattern, $message = null, $propertyPath = null) Assert that value matches a regex or that the value is null.
  * @method static void nullOrSame($value, $value2, $message = null, $propertyPath = null) Assert that two values are the same (using ===) or that the value is null.
+ * @method static void nullOrSatisfy($value, $callback, $message = null, $propertyPath = null) Assert that the provided value is valid according to a callback or that the value is null.
  * @method static void nullOrScalar($value, $message = null, $propertyPath = null) Assert that value is a PHP scalar or that the value is null.
  * @method static void nullOrStartsWith($string, $needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string starts with a sequence of chars or that the value is null.
  * @method static void nullOrString($value, $message = null, $propertyPath = null) Assert that value is a string or that the value is null.
@@ -208,6 +210,7 @@ class Assertion
     const INVALID_DATE              = 214;
     const INVALID_CALLABLE          = 215;
     const INVALID_KEY_NOT_EXISTS    = 216;
+    const INVALID_SATISFY           = 217;
 
     /**
      * Exception to throw when an assertion failed.
@@ -1752,6 +1755,28 @@ class Assertion
             );
 
             throw static::createException($value, $message, static::INVALID_CALLABLE, $propertyPath);
+        }
+    }
+
+    /**
+     * Assert that the provided value is valid according to a callback.
+     *
+     * If the callback returns `false` the assertion will fail.
+     *
+     * @param mixed $value
+     * @param callable $callback
+     * @param string|null $message
+     * @param string|null $propertyPath
+     */
+    public static function satisfy($value, $callback, $message = null, $propertyPath = null)
+    {
+        if (call_user_func($callback, $value) === false) {
+            $message = sprintf(
+                $message ?: 'Provided "%s" is invalid according to custom rule.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_SATISFY, $propertyPath);
         }
     }
 

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1770,6 +1770,8 @@ class Assertion
      */
     public static function satisfy($value, $callback, $message = null, $propertyPath = null)
     {
+        static::isCallable($callback);
+
         if (call_user_func($callback, $value) === false) {
             $message = sprintf(
                 $message ?: 'Provided "%s" is invalid according to custom rule.',

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -76,6 +76,7 @@ use ReflectionClass;
  * @method AssertionChain readable($message = null, $propertyPath = null) Assert that the value is something readable.
  * @method AssertionChain regex($pattern, $message = null, $propertyPath = null) Assert that value matches a regex.
  * @method AssertionChain same($value2, $message = null, $propertyPath = null) Assert that two values are the same (using ===).
+ * @method AssertionChain satisfy($callback, $message = null, $propertyPath = null) Assert that the provided value is valid according to a callback.
  * @method AssertionChain scalar($message = null, $propertyPath = null) Assert that value is a PHP scalar.
  * @method AssertionChain startsWith($needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string starts with a sequence of chars.
  * @method AssertionChain string($message = null, $propertyPath = null) Assert that value is a string.

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -73,6 +73,7 @@ namespace Assert;
  * @method LazyAssertion readable($message = null, $propertyPath = null) Assert that the value is something readable.
  * @method LazyAssertion regex($pattern, $message = null, $propertyPath = null) Assert that value matches a regex.
  * @method LazyAssertion same($value2, $message = null, $propertyPath = null) Assert that two values are the same (using ===).
+ * @method LazyAssertion satisfy($callback, $message = null, $propertyPath = null) Assert that the provided value is valid according to a callback.
  * @method LazyAssertion scalar($message = null, $propertyPath = null) Assert that value is a PHP scalar.
  * @method LazyAssertion startsWith($needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string starts with a sequence of chars.
  * @method LazyAssertion string($message = null, $propertyPath = null) Assert that value is a string.

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1188,6 +1188,29 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::isCallable(function () {
         });
     }
+
+    public function testInvalidSatisfy()
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_SATISFY);
+        Assertion::satisfy(null, function ($value) {
+            return !is_null($value);
+        });
+    }
+
+    public function testValidSatisfy()
+    {
+        // Should not fail with true return
+        Assertion::satisfy(null, function ($value) {
+            return is_null($value);
+        });
+
+        // Should not fail with void return
+        Assertion::satisfy(true, function ($value) {
+            if (!is_bool($value)) {
+                return false;
+            }
+        });
+    }
 }
 
 class ChildStdClass extends \stdClass

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -82,4 +82,14 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
     {
         \Assert\that(null)->unknownAssertion();
     }
+
+    /**
+     * @test
+     */
+    public function it_has_satisfy_shortcut()
+    {
+        \Assert\that(null)->satisfy(function ($value) {
+            return is_null($value);
+        });
+    }
 }


### PR DESCRIPTION
Sometimes an assertion will need to be more complex than any one method
available. In these cases, having a callback that returns a boolean is
a simple and effective solution.