### PR TITLE
Fix: Fail the build if docs haven't been updated properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ php:
 install:
   - composer update
 
-script: php vendor/bin/phpunit
+script:
+  - php vendor/bin/phpunit
+  - composer assert:generate-docs && [[ -z $(git status -s) ]] || echo "Please run composer assert:generate-docs and commit the changes"


### PR DESCRIPTION
This PR

* [x] fails the build if the docs haven't been updated properly

Follows https://github.com/beberlei/assert/pull/169#discussion_r77632343.