### PR TITLE
Fix: Do not use deprecated setExpectedException()

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 - Upgrade assertions to return true on successful assertion to allow this library to be used with PHP7's assert() functionality.
 - Refactor unit tests into sets of related assertions.
-- Refactor all unit tests to use the new recommend exception testing pattern as the current `setExpectedException()` method is deprecated.
 - Maybe refactor names to be isXxx - maybe - but probably too much BC issues. Aliases are an option for BC (separate function library).
   Not really sure of the mileage on this. May simply not be worth it for the sake of consistent naming.
 - Separate assertions into sets that deal with related themes:

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -23,7 +23,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidFloat($nonFloat)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_FLOAT);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_FLOAT);
+
         Assertion::float($nonFloat);
     }
 
@@ -52,7 +54,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidInteger($nonInteger)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_INTEGER);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_INTEGER);
+
         Assertion::integer($nonInteger);
     }
 
@@ -84,7 +88,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIntegerish($nonInteger)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_INTEGERISH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_INTEGERISH);
+
         Assertion::integerish($nonInteger);
     }
 
@@ -96,13 +102,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidBoolean()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_BOOLEAN);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_BOOLEAN);
+
         Assertion::boolean(1);
     }
 
     public function testInvalidScalar()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_SCALAR);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_SCALAR);
+
         Assertion::scalar(new \stdClass);
     }
 
@@ -130,7 +140,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNotEmpty($value)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::VALUE_EMPTY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::VALUE_EMPTY);
+
         Assertion::notEmpty($value);
     }
 
@@ -166,7 +178,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidEmpty($value)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::VALUE_NOT_EMPTY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::VALUE_NOT_EMPTY);
+
         Assertion::noContent($value);
     }
 
@@ -187,7 +201,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNull($value)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::VALUE_NOT_NULL);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::VALUE_NOT_NULL);
+
         Assertion::null($value);
     }
 
@@ -207,7 +223,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidNotNull()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::VALUE_NULL);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::VALUE_NULL);
+
         Assertion::notNull(null);
     }
 
@@ -222,7 +240,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidString($invalidString)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING);
+
         Assertion::string($invalidString);
     }
 
@@ -240,19 +260,25 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidRegex()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_REGEX);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_REGEX);
+
         Assertion::regex("foo", "(bar)");
     }
 
     public function testInvalidRegexValueNotString()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING);
+
         Assertion::regex(array("foo"), "(bar)");
     }
 
     public function testInvalidMinLength()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MIN_LENGTH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_MIN_LENGTH);
+
         Assertion::minLength("foo", 4);
     }
 
@@ -267,7 +293,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidMaxLength()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MAX_LENGTH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_MAX_LENGTH);
+
         Assertion::maxLength("foo", 2);
     }
 
@@ -281,13 +309,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidBetweenLengthMin()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MIN_LENGTH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_MIN_LENGTH);
+
         Assertion::betweenLength("foo", 4, 100);
     }
 
     public function testInvalidBetweenLengthMax()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_MAX_LENGTH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_MAX_LENGTH);
+
         Assertion::betweenLength("foo", 0, 2);
     }
 
@@ -299,13 +331,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidStartsWith()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING_START);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING_START);
+
         Assertion::startsWith("foo", "bar");
     }
 
     public function testInvalidStartsWithDueToWrongEncoding()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING_START);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING_START);
+
         Assertion::startsWith("址", "址址", null, null, 'ASCII');
     }
 
@@ -319,13 +355,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidEndsWith()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING_END);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING_END);
+
         Assertion::endsWith("foo", "bar");
     }
 
     public function testInvalidEndsWithDueToWrongEncoding()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING_END);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING_END);
+
         Assertion::endsWith("址", "址址", null, null, 'ASCII');
     }
 
@@ -339,7 +379,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidContains()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_STRING_CONTAINS);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_STRING_CONTAINS);
+
         Assertion::contains("foo", "bar");
     }
 
@@ -351,7 +393,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidChoice()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_CHOICE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_CHOICE);
+
         Assertion::choice("foo", array("bar", "baz"));
     }
 
@@ -362,7 +406,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidInArray()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_CHOICE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_CHOICE);
+
         Assertion::inArray("bar", array("baz"));
     }
 
@@ -373,7 +419,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidNumeric()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_NUMERIC);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_NUMERIC);
+
         Assertion::numeric("foo");
     }
 
@@ -402,7 +450,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArray($value)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_ARRAY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_ARRAY);
+
         Assertion::isArray($value);
     }
 
@@ -415,7 +465,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidKeyExists()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_KEY_EXISTS);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_KEY_EXISTS);
+
         Assertion::keyExists(array("foo" => "bar"), "baz");
     }
 
@@ -426,7 +478,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidKeyNotExists()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_KEY_NOT_EXISTS);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_KEY_NOT_EXISTS);
+
         Assertion::keyNotExists(array("foo" => "bar"), "foo");
     }
 
@@ -454,7 +508,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNotBlank($notBlank)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_NOT_BLANK);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_NOT_BLANK);
+
         Assertion::notBlank($notBlank);
     }
 
@@ -465,7 +521,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidNotInstanceOf()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_NOT_INSTANCE_OF);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_NOT_INSTANCE_OF);
+
         Assertion::notIsInstanceOf(new \stdClass, 'stdClass');
     }
 
@@ -476,7 +534,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidInstanceOf()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_INSTANCE_OF);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_INSTANCE_OF);
+
         Assertion::isInstanceOf(new \stdClass, 'PDO');
     }
 
@@ -487,7 +547,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidSubclassOf()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_SUBCLASS_OF);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_SUBCLASS_OF);
+
         Assertion::subclassOf(new \stdClass, 'PDO');
     }
 
@@ -498,7 +560,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidRange()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_RANGE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_RANGE);
+
         Assertion::range(1, 2, 3);
         Assertion::range(1.5, 2, 3);
     }
@@ -513,7 +577,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidEmail()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_EMAIL);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_EMAIL);
+
         Assertion::email("foo");
     }
 
@@ -527,7 +593,8 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidUrl($url)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_URL);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_URL);
 
         Assertion::url($url);
     }
@@ -566,7 +633,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidDigit()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_DIGIT);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_DIGIT);
+
         Assertion::digit(-1);
     }
 
@@ -587,7 +656,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidAlnum()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_ALNUM);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_ALNUM);
+
         Assertion::alnum("1a");
     }
 
@@ -598,7 +669,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidTrue()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_TRUE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_TRUE);
+
         Assertion::true(false);
     }
 
@@ -609,13 +682,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidFalse()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_FALSE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_FALSE);
+
         Assertion::false(true);
     }
 
     public function testInvalidClass()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_CLASS);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_CLASS);
+
         Assertion::classExists("Foo");
     }
 
@@ -629,7 +706,10 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::same(1,1);
         Assertion::same("foo","foo");
         Assertion::same($obj = new \stdClass(), $obj);
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_SAME);
+
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_SAME);
+
         Assertion::same(new \stdClass(), new \stdClass());
     }
 
@@ -638,7 +718,10 @@ class AssertTest extends \PHPUnit_Framework_TestCase
         Assertion::eq(1,"1");
         Assertion::eq("foo",true);
         Assertion::eq($obj = new \stdClass(), $obj);
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_EQ);
+
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_EQ);
+
         Assertion::eq("2", 1);
     }
 
@@ -646,7 +729,10 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::NotEq("1", false);
         Assertion::NotEq(new \stdClass(), array());
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_NOT_EQ);
+
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_NOT_EQ);
+
         Assertion::NotEq("1", 1);
     }
 
@@ -654,7 +740,10 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::notSame("1", 2);
         Assertion::notSame(new \stdClass(), array());
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_NOT_SAME);
+
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_NOT_SAME);
+
         Assertion::notSame(1, 1);
     }
 
@@ -662,7 +751,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::notInArray(6, range(1, 5));
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_VALUE_IN_ARRAY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_VALUE_IN_ARRAY);
+
         Assertion::notInArray(1, range(1, 5));
         Assertion::notInArray(range('a', 'c'), range('a', 'd'));
     }
@@ -721,7 +812,8 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testNullOrWithNoValueThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException('BadMethodCallException');
+
         Assertion::nullOrMax();
     }
 
@@ -749,13 +841,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testLengthFailed()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_LENGTH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_LENGTH);
+
         Assertion::length("asdf", 3);
     }
 
     public function testLengthFailedForWrongEncoding()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_LENGTH);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_LENGTH);
+
         Assertion::length("址", 1, null, null, 'ASCII');
     }
 
@@ -771,13 +867,17 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testFileWithEmptyFilename()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::VALUE_EMPTY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::VALUE_EMPTY);
+
         Assertion::file("");
     }
 
     public function testFileDoesNotExists()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_FILE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_FILE);
+
         Assertion::file(__DIR__ . '/does-not-exists');
     }
 
@@ -785,7 +885,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::directory(__DIR__);
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_DIRECTORY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_DIRECTORY);
+
         Assertion::directory(__DIR__ . '/does-not-exist');
     }
 
@@ -793,7 +895,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::readable(__FILE__);
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_READABLE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_READABLE);
+
         Assertion::readable(__DIR__ . '/does-not-exist');
     }
 
@@ -801,7 +905,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::writeable(sys_get_temp_dir());
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_WRITEABLE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_WRITEABLE);
+
         Assertion::writeable(__DIR__ . '/does-not-exist');
     }
 
@@ -821,7 +927,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
             '\Traversable'
         );
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INTERFACE_NOT_IMPLEMENTED);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INTERFACE_NOT_IMPLEMENTED);
+
         Assertion::implementsInterface(
             '\Exception',
             '\Traversable'
@@ -837,7 +945,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
             '\Traversable'
         );
 
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INTERFACE_NOT_IMPLEMENTED);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INTERFACE_NOT_IMPLEMENTED);
+
         Assertion::implementsInterface(
             $class,
             '\SplObserver'
@@ -867,7 +977,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsJsonStringExpectingException($invalidString)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_JSON_STRING);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_JSON_STRING);
+
         Assertion::isJsonString($invalidString);
     }
 
@@ -892,7 +1004,8 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidUuids($uuid)
     {
-        $this->setExpectedException('Assert\InvalidArgumentException');
+        $this->expectException('Assert\InvalidArgumentException');
+
         Assertion::uuid($uuid);
     }
 
@@ -932,7 +1045,8 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidE164s($e164)
     {
-        $this->setExpectedException('Assert\InvalidArgumentException');
+        $this->expectException('Assert\InvalidArgumentException');
+
         Assertion::e164($e164);
     }
 
@@ -963,7 +1077,8 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidNotEmptyKey($invalidArray, $key)
     {
-        $this->setExpectedException('Assert\InvalidArgumentException');
+        $this->expectException('Assert\InvalidArgumentException');
+
         Assertion::notEmptyKey($invalidArray, $key);
     }
 
@@ -982,7 +1097,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testAllWithSimpleAssertionThrowsExceptionOnElementThatFailsAssertion()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_TRUE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_TRUE);
+
         Assertion::allTrue(array(true, false));
     }
 
@@ -993,14 +1110,16 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testAllWithComplexAssertionThrowsExceptionOnElementThatFailsAssertion()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', 'Assertion failed', Assertion::INVALID_INSTANCE_OF);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_INSTANCE_OF);
 
         Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'PDO', 'Assertion failed', 'foos');
     }
 
     public function testAllWithNoValueThrows()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException('BadMethodCallException');
+
         Assertion::allTrue();
     }
 
@@ -1023,7 +1142,10 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidCount($countable, $count)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', 'List does not contain exactly "'.$count.'" elements.', Assertion::INVALID_COUNT);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionMessage('List does not contain exactly "'.$count.'" elements.');
+        $this->expectExceptionCode(Assertion::INVALID_COUNT);
+
         Assertion::count($countable, $count);
     }
 
@@ -1040,7 +1162,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testChoicesNotEmptyExpectingException($values, $choices, $exceptionCode)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, $exceptionCode);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode($exceptionCode);
+
         Assertion::choicesNotEmpty(
             $values,
             $choices
@@ -1063,7 +1187,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testIsObjectExpectingException()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_OBJECT);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_OBJECT);
+
         Assertion::isObject('notAnObject');
     }
 
@@ -1074,7 +1200,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testMethodExistsFailure()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_METHOD);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_METHOD);
+
         Assertion::methodExists('methodNotExists', new Assertion());
     }
 
@@ -1118,7 +1246,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testLessThanThrowsException($value, $limit)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_LESS);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_LESS);
+
         Assertion::lessThan($value, $limit);
     }
 
@@ -1147,7 +1277,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testLessOrEqualThanThrowsException($value, $limit)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_LESS_OR_EQUAL);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_LESS_OR_EQUAL);
+
         Assertion::lessOrEqualThan($value, $limit);
     }
 
@@ -1194,7 +1326,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testGreaterThanThrowsException($value, $limit)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_GREATER);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_GREATER);
+
         Assertion::greaterThan($value, $limit);
     }
 
@@ -1226,7 +1360,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testGreaterOrEqualThanThrowsException($value, $limit)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_GREATER_OR_EQUAL);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_GREATER_OR_EQUAL);
+
         Assertion::greaterOrEqualThan($value, $limit);
     }
 
@@ -1235,7 +1371,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidDate($value, $format)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_DATE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_DATE);
+
         Assertion::date($value, $format);
     }
 
@@ -1250,19 +1388,25 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidTraversable()
     {
-        $this->setExpectedException('Assert\InvalidArgumentException', null, Assertion::INVALID_TRAVERSABLE);
+        $this->expectException('Assert\InvalidArgumentException');
+        $this->expectExceptionCode(Assertion::INVALID_TRAVERSABLE);
+
         Assertion::isTraversable('not traversable');
     }
 
     public function testInvalidArrayAccessible()
     {
-        $this->setExpectedException('Assert\InvalidArgumentException', null, Assertion::INVALID_ARRAY_ACCESSIBLE);
+        $this->expectException('Assert\InvalidArgumentException');
+        $this->expectExceptionCode(Assertion::INVALID_ARRAY_ACCESSIBLE);
+
         Assertion::isArrayAccessible('not array accessible');
     }
 
     public function testInvalidCallable()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_CALLABLE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_CALLABLE);
+
         Assertion::isCallable("nonExistingFunction");
     }
 
@@ -1277,7 +1421,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidSatisfy()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_SATISFY);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_SATISFY);
+
         Assertion::satisfy(null, function ($value) {
             return !is_null($value);
         });
@@ -1318,7 +1464,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      * @dataProvider invalidIpProvider
      */
     public function testInvalidIp($value, $flag = null) {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_IP);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_IP);
+
         Assertion::ip($value, $flag);
     }
 
@@ -1339,7 +1487,9 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testInvalidIpv4() {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_IP);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_IP);
+
         Assertion::ipv4('2001:db8:85a3:8d3:1319:8a2e:370:7348');
     }
 
@@ -1349,19 +1499,25 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidIpv6()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_IP);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_IP);
+
         Assertion::ipv6('109.188.127.26');
     }
 
     public function testInvalidInterfaceExists()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_INTERFACE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_INTERFACE);
+
         Assertion::interfaceExists("Foo");
     }
 
     public function testValidInterfaceExists()
     {
-        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_INTERFACE);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(Assertion::INVALID_INTERFACE);
+
         Assertion::interfaceExists("\\Countable");
     }
 }

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -36,7 +36,8 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_knowns_default_error_message()
     {
-        $this->setExpectedException('Assert\InvalidArgumentException', 'Not Null and such');
+        $this->expectException('Assert\InvalidArgumentException');
+        $this->expectExceptionMessage('Not Null and such');
 
         \Assert\that(null, 'Not Null and such')->notEmpty();
     }

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -11,7 +11,8 @@ class LazyAssertionTest extends \PHPUnit_Framework_TestCase
      */
     public function it_collects_errors_until_assertall()
     {
-        $this->setExpectedException('Assert\LazyAssertionException', <<<EXC
+        $this->expectException('Assert\LazyAssertionException');
+        $this->expectExceptionMessage(<<<EXC
 The following 3 assertions failed:
 1) foo: Value "10" expected to be string, type integer given.
 2) bar: Value "<NULL>" is empty, but non empty value was expected.
@@ -32,7 +33,8 @@ EXC
      */
     public function it_skips_assertions_of_current_chain_after_failure()
     {
-        $this->setExpectedException('Assert\LazyAssertionException', <<<EXC
+        $this->expectException('Assert\LazyAssertionException');
+        $this->expectExceptionMessage(<<<EXC
 The following 1 assertions failed:
 1) foo: Value "<NULL>" is empty, but non empty value was expected.
 

--- a/tests/Assert/Tests/PR142_AllowOverridingStringifyTest.php
+++ b/tests/Assert/Tests/PR142_AllowOverridingStringifyTest.php
@@ -26,7 +26,10 @@ class PR142_AllowOverridingStringifyTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidStringWithOverriddenStringify($invalidString, $exceptionMessage)
     {
-        $this->setExpectedException('Assert\AssertionFailedException', $exceptionMessage, Assertion::INVALID_STRING);
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionMessage($exceptionMessage);
+        $this->expectExceptionCode(Assertion::INVALID_STRING);
+
         PR142_OverrideStringify::string($invalidString);
     }
 }


### PR DESCRIPTION
This PR

* [x] removes usages of the deprecated method `setExpectedException()`