### PR TITLE
Gitattributes completion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,15 @@
 # Auto detect text files and perform LF normalization
 *           text=auto
 
-bin/ export-ignore
-tests/ export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+bin/ export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore
 LICENSE export-ignore
 phpunit.xml.dist export-ignore
 README.md export-ignore
+tests/ export-ignore
 TODO.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 # Auto detect text files and perform LF normalization
 *           text=auto
 
-/bin export-ignore
-/tests export-ignore
+bin/ export-ignore
+tests/ export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,9 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore
 LICENSE export-ignore
 phpunit.xml.dist export-ignore
 README.md export-ignore
+TODO.md export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,5 @@ Thanks for contributing to assert! Just follow these single guidelines:
 
 - You must use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.
 - After adding new assertions regenerate the [README.md](README.md) and the docblocks by running `composer assert:generate-docs` on the command line.
+- After adding new non release relevant artifacts you must ensure they are export ignored in the [.gitattributes](.gitattributes) file.
 


### PR DESCRIPTION
Fixed _mainly_  the `.gitattributes` file so that releases don't contain unnecessary files (i.e. CHANGELOG.md and TODO.md).

As a rule of thumb: all additional files, which shouldn't end up in the release / dist file, must be added to the `.gitattributes` file. Maybe this should go also in `CONTRIBUTING.md`.