### PR TITLE
Enhancement: Implement between() and betweenExclusive() assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 2.6.* - unreleased
+### Added assertions
+- `Assert\Assertion::between()`
+- `Assert\Assertion::betweenExclusive()`
+
 ## 2.6.4 - 2016-10-03
 ### Added assertions
 - `Assert\Assertion::e164()` - The international public telecommunication numbering plan

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ This can be useful for example to build a failure response for the user.
 use Assert\Assertion;
 
 Assertion::alnum($value);
+Assertion::between($value, $lowerLimit, $upperLimit);
+Assertion::betweenExclusive($value, $lowerLimit, $upperLimit);
 Assertion::betweenLength($value, $minLength, $maxLength);
 Assertion::boolean($value);
 Assertion::choice($value, $choices);

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -21,6 +21,8 @@ use BadMethodCallException;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  *
  * @method static void allAlnum($value, $message = null, $propertyPath = null) Assert that value is alphanumeric for all values.
+ * @method static void allBetween($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit for all values.
+ * @method static void allBetweenExclusive($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit for all values.
  * @method static void allBetweenLength($value, $minLength, $maxLength, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string length is between min,max lengths for all values.
  * @method static void allBoolean($value, $message = null, $propertyPath = null) Assert that value is php boolean for all values.
  * @method static void allChoice($value, $choices, $message = null, $propertyPath = null) Assert that value is in array of choices for all values.
@@ -91,6 +93,8 @@ use BadMethodCallException;
  * @method static void allUuid($value, $message = null, $propertyPath = null) Assert that the given string is a valid UUID for all values.
  * @method static void allWriteable($value, $message = null, $propertyPath = null) Assert that the value is something writeable for all values.
  * @method static void nullOrAlnum($value, $message = null, $propertyPath = null) Assert that value is alphanumeric or that the value is null.
+ * @method static void nullOrBetween($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit or that the value is null.
+ * @method static void nullOrBetweenExclusive($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit or that the value is null.
  * @method static void nullOrBetweenLength($value, $minLength, $maxLength, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string length is between min,max lengths or that the value is null.
  * @method static void nullOrBoolean($value, $message = null, $propertyPath = null) Assert that value is php boolean or that the value is null.
  * @method static void nullOrChoice($value, $choices, $message = null, $propertyPath = null) Assert that value is in array of choices or that the value is null.
@@ -227,6 +231,8 @@ class Assertion
     const INVALID_KEY_NOT_EXISTS    = 216;
     const INVALID_SATISFY           = 217;
     const INVALID_IP                = 218;
+    const INVALID_BETWEEN           = 219;
+    const INVALID_BETWEEN_EXCLUSIVE = 220;
 
     /**
      * Exception to throw when an assertion failed.
@@ -1788,6 +1794,52 @@ class Assertion
             );
 
             throw static::createException($value, $message, static::INVALID_GREATER_OR_EQUAL, $propertyPath);
+        }
+    }
+
+    /**
+     * Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit.
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     * @param string $message
+     * @param string $propertyPath
+     */
+    public static function between($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null)
+    {
+        if ($lowerLimit > $value || $value > $upperLimit) {
+            $message = sprintf(
+                $message ?: 'Provided "%s" is neither greater than or equal to "%s" nor less than or equal to "%s".',
+                static::stringify($value),
+                static::stringify($lowerLimit),
+                static::stringify($upperLimit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_BETWEEN, $propertyPath);
+        }
+    }
+
+    /**
+     * Assert that a value is greater than a lower limit, and less than an upper limit.
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     * @param string $message
+     * @param string $propertyPath
+     */
+    public static function betweenExclusive($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null)
+    {
+        if ($lowerLimit >= $value || $value >= $upperLimit) {
+            $message = sprintf(
+                $message ?: 'Provided "%s" is neither greater than "%s" nor less than "%s".',
+                static::stringify($value),
+                static::stringify($lowerLimit),
+                static::stringify($upperLimit)
+            );
+
+            throw static::createException($value, $message, static::INVALID_BETWEEN_EXCLUSIVE, $propertyPath);
         }
     }
 

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -22,6 +22,8 @@ use ReflectionClass;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  *
  * @method AssertionChain alnum($message = null, $propertyPath = null) Assert that value is alphanumeric.
+ * @method AssertionChain between($lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit.
+ * @method AssertionChain betweenExclusive($lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit.
  * @method AssertionChain betweenLength($minLength, $maxLength, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string length is between min,max lengths.
  * @method AssertionChain boolean($message = null, $propertyPath = null) Assert that value is php boolean.
  * @method AssertionChain choice($choices, $message = null, $propertyPath = null) Assert that value is in array of choices.

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -19,6 +19,8 @@ namespace Assert;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  *
  * @method LazyAssertion alnum($message = null, $propertyPath = null) Assert that value is alphanumeric.
+ * @method LazyAssertion between($lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit.
+ * @method LazyAssertion betweenExclusive($lowerLimit, $upperLimit, $message = null, $propertyPath = null) Assert that a value is greater than a lower limit, and less than an upper limit.
  * @method LazyAssertion betweenLength($minLength, $maxLength, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string length is between min,max lengths.
  * @method LazyAssertion boolean($message = null, $propertyPath = null) Assert that value is php boolean.
  * @method LazyAssertion choice($choices, $message = null, $propertyPath = null) Assert that value is in array of choices.

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -3,6 +3,7 @@ namespace Assert\Tests;
 
 use Assert\Assertion;
 use Assert\AssertionFailedException;
+use Webmozart\Assert\Assert;
 
 class AssertTest extends \PHPUnit_Framework_TestCase
 {
@@ -1363,6 +1364,115 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_INTERFACE);
         Assertion::interfaceExists("\\Countable");
+    }
+
+    /**
+     * @dataProvider providerInvalidBetween
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     */
+    public function testInvalidBetween($value, $lowerLimit, $upperLimit)
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_BETWEEN);
+
+        Assertion::between($value, $lowerLimit, $upperLimit);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerInvalidBetween()
+    {
+        return array(
+            array(1, 2, 3),
+            array(3, 1, 2),
+            array('aaa', 'bbb', 'ccc'),
+            array('ddd', 'bbb', 'ccc'),
+            array(new \DateTime('yesterday'), new \DateTime('today'), new \DateTime('tomorrow')),
+            array(new \DateTime('tomorrow'), new \DateTime('yesterday'), new \DateTime('today')),
+        );
+    }
+
+    /**
+     * @dataProvider providerValidBetween
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     */
+    public function testValidBetween($value, $lowerLimit, $upperLimit)
+    {
+        $this->assertNull(Assertion::between($value, $lowerLimit, $upperLimit));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerValidBetween()
+    {
+        return array(
+            array(2, 1, 3),
+            array(1, 1, 1),
+            array('bbb', 'aaa', 'ccc'),
+            array('aaa', 'aaa', 'aaa'),
+            array(new \DateTime('today'), new \DateTime('yesterday'), new \DateTime('tomorrow')),
+            array(new \DateTime('today'), new \DateTime('today'), new \DateTime('today')),
+        );
+    }
+
+    /**
+     * @dataProvider providerInvalidBetweenExclusive
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     */
+    public function testInvalidBetweenExclusive($value, $lowerLimit, $upperLimit)
+    {
+        $this->setExpectedException('Assert\AssertionFailedException', null, Assertion::INVALID_BETWEEN_EXCLUSIVE);
+
+        Assertion::betweenExclusive($value, $lowerLimit, $upperLimit);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerInvalidBetweenExclusive()
+    {
+        return array(
+            array(1, 1, 2),
+            array(2, 1, 2),
+            array('aaa', 'aaa', 'bbb'),
+            array('bbb', 'aaa', 'bbb'),
+            array(new \DateTime('today'), new \DateTime('today'), new \DateTime('tomorrow')),
+            array(new \DateTime('tomorrow'), new \DateTime('today'), new \DateTime('tomorrow')),
+        );
+    }
+
+    /**
+     * @dataProvider providerValidBetweenExclusive
+     *
+     * @param mixed $value
+     * @param mixed $lowerLimit
+     * @param mixed $upperLimit
+     */
+    public function testValidBetweenExclusive($value, $lowerLimit, $upperLimit)
+    {
+        $this->assertNull(Assertion::betweenExclusive($value, $lowerLimit, $upperLimit));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerValidBetweenExclusive()
+    {
+        return array(
+            array(2, 1, 3),
+            array('bbb', 'aaa', 'ccc'),
+            array(new \DateTime('today'), new \DateTime('yesterday'), new \DateTime('tomorrow')),
+        );
     }
 }
 


### PR DESCRIPTION
This PR

* [x] implements `between()` and `betweenExclusive()` assertions

Fixes #171.

/cc @holtkamp 