### PR TITLE
Use static factory methods instead of functions in the Assert namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,34 +82,34 @@ Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'stdClass'); // 
 Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'PDO');      // exception
 ```
 
-### \Assert\that() Chaining
+### Assert::that() Chaining
 
 Using the static API on values is very verbose when checking values against multiple assertions.
 Starting with 2.0 of Assert there is a much nicer fluent API for assertions, starting
-with ``\Assert\that($value)`` and then receiving the assertions you want to call
+with ``Assert::that($value)`` and then receiving the assertions you want to call
 on the fluent interface. You only have to specify the `$value` once.
 
 ```php
 <?php
-\Assert\that($value)->notEmpty()->integer();
-\Assert\that($value)->nullOr()->string()->startsWith("Foo");
-\Assert\that($values)->all()->float();
+Assert::that($value)->notEmpty()->integer();
+Assert::that($value)->nullOr()->string()->startsWith("Foo");
+Assert::that($values)->all()->float();
 ```
 
-There are also two shortcut function ``\Assert\thatNullOr()`` and ``\Assert\thatAll()`` enabling
+There are also two shortcut function ``Assert::thatNullOr()`` and ``Assert::thatAll()`` enabling
 the "nullOr" or "all" helper respectively.
 
 ### Lazy Assertions
 
 There are many cases in web development, especially when involving forms, you want to collect several errors
 instead of aborting directly on the first error. This is what lazy assertions are for. Their API
-works exactly like the fluent ``\Assert\that()`` API, but instead of throwing an Exception directly,
+works exactly like the fluent ``Assert::that()`` API, but instead of throwing an Exception directly,
 they collect all errors and only trigger the exception when the method
 ``verifyNow()`` is called on the ``Assert\SoftAssertion`` object.
 
 ```php
 <?php
-\Assert\lazy()
+Assert::lazy()
     ->that(10, 'foo')->string()
     ->that(null, 'bar')->notEmpty()
     ->that('string', 'baz')->isArray()

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -13,7 +13,11 @@
 
 namespace Assert;
 
-if (!function_exists(__NAMESPACE__ . '\that')) {
+/**
+ * AssertionChain factory
+ */
+abstract class Assert
+{
     /**
      * Start validation on a value, returns {@link AssertionChain}
      *
@@ -22,67 +26,57 @@ if (!function_exists(__NAMESPACE__ . '\that')) {
      *
      * @example
      *
-     *  \Assert\that($value)->notEmpty()->integer();
-     *  \Assert\that($value)->nullOr()->string()->startsWith("Foo");
+     *  Assert::that($value)->notEmpty()->integer();
+     *  Assert::that($value)->nullOr()->string()->startsWith("Foo");
      *
      * The assertion chain can be stateful, that means be careful when you reuse
      * it. You should never pass around the chain.
      *
-     * @param mixed  $value
+     * @param mixed $value
      * @param string $defaultMessage
      * @param string $defaultPropertyPath
      *
      * @return \Assert\AssertionChain
-     * @deprecated
      */
-    function that($value, $defaultMessage = null, $defaultPropertyPath = null)
+    public static function that($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return Assert::that($value, $defaultMessage, $defaultPropertyPath);
+        return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
     }
-}
 
-if (!function_exists(__NAMESPACE__ . '\thatAll')) {
     /**
      * Start validation on a set of values, returns {@link AssertionChain}
      *
-     * @param mixed  $values
+     * @param mixed $values
      * @param string $defaultMessage
      * @param string $defaultPropertyPath
      *
      * @return \Assert\AssertionChain
-     * @deprecated
      */
-    function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
+    public static function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return Assert::that($values, $defaultMessage, $defaultPropertyPath)->all();
+        return static::that($values, $defaultMessage, $defaultPropertyPath)->all();
     }
-}
 
-if (!function_exists(__NAMESPACE__ . '\thatNullOr')) {
     /**
      * Start validation and allow NULL, returns {@link AssertionChain}
      *
-     * @param mixed  $value
+     * @param mixed $value
      * @param string $defaultMessage
      * @param string $defaultPropertyPath
      *
      * @return \Assert\AssertionChain
-     * @deprecated
      */
-    function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
+    public static function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return Assert::that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
+        return static::that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
     }
-}
 
-if (!function_exists(__NAMESPACE__ . '\lazy')) {
     /**
      * Create a lazy assertion object.
      *
      * @return \Assert\LazyAssertion
-     * @deprecated
      */
-    function lazy()
+    public static function lazy()
     {
         return new LazyAssertion();
     }

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -21,6 +21,9 @@ abstract class Assert
     /** @var string */
     protected static $lazyAssertionExceptionClass = LazyAssertionException::class;
 
+    /** @var string */
+    protected static $assertionClass = Assertion::class;
+
     /**
      * Start validation on a value, returns {@link AssertionChain}
      *
@@ -43,7 +46,9 @@ abstract class Assert
      */
     public static function that($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+        return (new AssertionChain($value, $defaultMessage, $defaultPropertyPath))
+            ->setAssertionClassName(static::$assertionClass)
+        ;
     }
 
     /**

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -18,6 +18,9 @@ namespace Assert;
  */
 abstract class Assert
 {
+    /** @var string */
+    protected static $lazyAssertionExceptionClass = LazyAssertionException::class;
+
     /**
      * Start validation on a value, returns {@link AssertionChain}
      *
@@ -78,6 +81,8 @@ abstract class Assert
      */
     public static function lazy()
     {
-        return new LazyAssertion();
+        return (new LazyAssertion())
+            ->setExceptionClass(static::$lazyAssertionExceptionClass)
+        ;
     }
 }

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -14,6 +14,7 @@
 
 namespace Assert;
 
+use LogicException;
 use ReflectionClass;
 
 /**
@@ -114,6 +115,9 @@ class AssertionChain
      */
     private $all = false;
 
+    /** @var string|Assertion Class to use for assertion calls */
+    private $assertionClassName = Assertion::class;
+
     public function __construct($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
         $this->value = $value;
@@ -135,11 +139,11 @@ class AssertionChain
             return $this;
         }
 
-        if (!method_exists('Assert\Assertion', $methodName)) {
+        if (!method_exists($this->assertionClassName, $methodName)) {
             throw new \RuntimeException("Assertion '" . $methodName . "' does not exist.");
         }
 
-        $reflClass = new ReflectionClass('Assert\Assertion');
+        $reflClass = new ReflectionClass($this->assertionClassName);
         $method = $reflClass->getMethod($methodName);
 
         array_unshift($args, $this->value);
@@ -163,7 +167,7 @@ class AssertionChain
             $methodName = 'all' . $methodName;
         }
 
-        call_user_func_array(array('Assert\Assertion', $methodName), $args);
+        call_user_func_array(array($this->assertionClassName, $methodName), $args);
 
         return $this;
     }
@@ -191,6 +195,20 @@ class AssertionChain
             $this->alwaysValid = true;
         }
 
+        return $this;
+    }
+
+    /**
+     * @param string $className
+     * @return $this
+     */
+    public function setAssertionClassName($className)
+    {
+        if ($className !== Assertion::class && !is_subclass_of($className, Assertion::class)) {
+            throw new LogicException($className . ' is not (a subclass of) ' . Assertion::class);
+        }
+
+        $this->assertionClassName = $className;
         return $this;
     }
 }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -102,7 +102,7 @@ class LazyAssertion
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
-        $this->currentChain = \Assert\that($value, $defaultMessage, $propertyPath);
+        $this->currentChain = Assert::that($value, $defaultMessage, $propertyPath);
 
         return $this;
     }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -13,6 +13,8 @@
 
 namespace Assert;
 
+use LogicException;
+
 /**
  * Chaining builder for lazy assertions
  *
@@ -99,6 +101,9 @@ class LazyAssertion
     private $currentChain;
     private $errors = array();
 
+    /** @var string|LazyAssertionException The class to use for exceptions */
+    private $exceptionClass = LazyAssertionException::class;
+
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
@@ -130,9 +135,23 @@ class LazyAssertion
     public function verifyNow()
     {
         if ($this->errors) {
-            throw LazyAssertionException::fromErrors($this->errors);
+            throw call_user_func([$this->exceptionClass, 'fromErrors'], $this->errors);
         }
 
         return true;
+    }
+
+    /**
+     * @param string $className
+     * @return $this
+     */
+    public function setExceptionClass($className)
+    {
+        if ($className !== LazyAssertionException::class && !is_subclass_of($className, LazyAssertionException::class)) {
+            throw new LogicException($className . ' is not (a subclass of) ' . LazyAssertionException::class);
+        }
+
+        $this->exceptionClass = $className;
+        return $this;
     }
 }

--- a/lib/Assert/LazyAssertionException.php
+++ b/lib/Assert/LazyAssertionException.php
@@ -33,7 +33,7 @@ class LazyAssertionException extends \InvalidArgumentException
             $message .= sprintf("%d) %s: %s\n", $i++, $error->getPropertyPath(), $error->getMessage());
         }
 
-        return new self($message, $errors);
+        return new static($message, $errors);
     }
 
     public function __construct($message, array $errors)

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -13,6 +13,8 @@
 
 namespace Assert\Tests;
 
+use Assert\Assert;
+
 class AssertionChainTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -20,7 +22,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_chains_assertions()
     {
-        \Assert\that(10)->notEmpty()->integer();
+        Assert::that(10)->notEmpty()->integer();
     }
 
     /**
@@ -28,7 +30,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_shifts_arguments_to_assertions_by_one()
     {
-        \Assert\that(10)->eq(10);
+        Assert::that(10)->eq(10);
     }
 
     /**
@@ -38,7 +40,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Assert\InvalidArgumentException', 'Not Null and such');
 
-        \Assert\that(null, 'Not Null and such')->notEmpty();
+        Assert::that(null, 'Not Null and such')->notEmpty();
     }
 
     /**
@@ -46,7 +48,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_skips_assertions_on_valid_null()
     {
-        \Assert\that(null)->nullOr()->integer()->eq(10);
+        Assert::that(null)->nullOr()->integer()->eq(10);
     }
 
     /**
@@ -54,7 +56,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_validates_all_inputs()
     {
-        \Assert\that(array(1, 2, 3))->all()->integer();
+        Assert::that(array(1, 2, 3))->all()->integer();
     }
 
     /**
@@ -62,7 +64,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_thatall_shortcut()
     {
-        \Assert\thatAll(array(1, 2, 3))->integer();
+        Assert::thatAll(array(1, 2, 3))->integer();
     }
 
     /**
@@ -70,7 +72,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_nullor_shortcut()
     {
-        \Assert\thatNullOr(null)->integer()->eq(10);
+        Assert::thatNullOr(null)->integer()->eq(10);
     }
 
     /**
@@ -80,7 +82,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_throws_exception_for_unknown_assertion()
     {
-        \Assert\that(null)->unknownAssertion();
+        Assert::that(null)->unknownAssertion();
     }
 
     /**
@@ -88,7 +90,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_satisfy_shortcut()
     {
-        \Assert\that(null)->satisfy(function ($value) {
+        Assert::that(null)->satisfy(function ($value) {
             return is_null($value);
         });
     }

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+use Assert\Assert;
+use Assert\Assertion;
+use Assert\InvalidArgumentException;
+use Assert\LazyAssertionException;
+
+class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        CustomAssertion::clearCalls();
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_class()
+    {
+        $this->expectException(CustomException::class);
+        CustomAssertion::integer('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_assertion_class_for_assertion_chains()
+    {
+        $string = 's' . uniqid();
+        CustomAssert::that($string)->string();
+        $this->assertSame([['string', $string]], CustomAssertion::getCalls());
+
+        $this->expectException(CustomException::class);
+        CustomAssert::that($string)->integer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_for_lazy_assertion_chains()
+    {
+        $this->expectException(CustomLazyAssertionException::class);
+        CustomAssert::lazy()
+            ->that('foo', 'foo')->integer()
+            ->verifyNow()
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_for_lazy_assertion_chains_when_first_assertion_does_not_fail()
+    {
+        $this->expectException(CustomLazyAssertionException::class);
+        CustomAssert::lazy()
+            ->that('foo', 'foo')->string()
+            ->that('bar', 'bar')->integer()
+            ->verifyNow()
+        ;
+    }
+}
+
+class CustomException extends InvalidArgumentException
+{
+}
+
+class CustomLazyAssertionException extends LazyAssertionException
+{
+}
+
+class CustomAssertion extends Assertion
+{
+    protected static $exceptionClass = CustomException::class;
+    private static $calls = [];
+
+    public static function clearCalls()
+    {
+        self::$calls = [];
+    }
+
+    public static function getCalls()
+    {
+        return self::$calls;
+    }
+
+    public static function string($value, $message = null, $propertyPath = null)
+    {
+        self::$calls[] = ['string', $value];
+        return parent::string($value, $message, $propertyPath);
+    }
+}
+
+class CustomAssert extends Assert
+{
+    protected static $assertionClass = CustomAssertion::class;
+    protected static $lazyAssertionExceptionClass = CustomLazyAssertionException::class;
+}

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -2,6 +2,7 @@
 
 namespace Assert\Tests;
 
+use Assert\Assert;
 use Assert\LazyAssertionException;
 
 class LazyAssertionTest extends \PHPUnit_Framework_TestCase
@@ -20,7 +21,7 @@ The following 3 assertions failed:
 EXC
         );
 
-        \Assert\lazy()
+        Assert::lazy()
             ->that(10, 'foo')->string()
             ->that(null, 'bar')->notEmpty()
             ->that('string', 'baz')->isArray()
@@ -39,7 +40,7 @@ The following 1 assertions failed:
 EXC
         );
 
-        \Assert\lazy()
+        Assert::lazy()
             ->that(null, 'foo')->notEmpty()->string()
             ->verifyNow();
     }
@@ -47,7 +48,7 @@ EXC
     public function testLazyAssertionExceptionCanReturnAllErrors()
     {
         try {
-            \Assert\lazy()
+            Assert::lazy()
                 ->that(10, 'foo')->string()
                 ->that(null, 'bar')->notEmpty()
                 ->that('string', 'baz')->isArray()
@@ -66,7 +67,7 @@ EXC
     public function testVerifyNowReturnsTrueIfAssertionsPass()
     {
         $this->assertTrue(
-            \Assert\lazy()
+            Assert::lazy()
                 ->that(2, 'Two')->eq(2)
                 ->verifyNow()
         );


### PR DESCRIPTION
The functions in the Assert namespace can not be autoloaded, nor can they be used with alternative exception classes. This pull request resolves these issues by introducing a static factory class (\Assert\Assert) that provides these functions as static methods. This will also solve beberlei/assert#57.