### PR TITLE
Use static factory methods instead of functions in the Assert namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,34 +82,34 @@ Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'stdClass'); // 
 Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'PDO');      // exception
 ```
 
-### \Assert\that() Chaining
+### Assert::that() Chaining
 
 Using the static API on values is very verbose when checking values against multiple assertions.
 Starting with 2.0 of Assert there is a much nicer fluent API for assertions, starting
-with ``\Assert\that($value)`` and then receiving the assertions you want to call
+with ``Assert::that($value)`` and then receiving the assertions you want to call
 on the fluent interface. You only have to specify the `$value` once.
 
 ```php
 <?php
-\Assert\that($value)->notEmpty()->integer();
-\Assert\that($value)->nullOr()->string()->startsWith("Foo");
-\Assert\that($values)->all()->float();
+Assert::that($value)->notEmpty()->integer();
+Assert::that($value)->nullOr()->string()->startsWith("Foo");
+Assert::that($values)->all()->float();
 ```
 
-There are also two shortcut function ``\Assert\thatNullOr()`` and ``\Assert\thatAll()`` enabling
+There are also two shortcut function ``Assert::thatNullOr()`` and ``Assert::thatAll()`` enabling
 the "nullOr" or "all" helper respectively.
 
 ### Lazy Assertions
 
 There are many cases in web development, especially when involving forms, you want to collect several errors
 instead of aborting directly on the first error. This is what lazy assertions are for. Their API
-works exactly like the fluent ``\Assert\that()`` API, but instead of throwing an Exception directly,
+works exactly like the fluent ``Assert::that()`` API, but instead of throwing an Exception directly,
 they collect all errors and only trigger the exception when the method
 ``verifyNow()`` is called on the ``Assert\SoftAssertion`` object.
 
 ```php
 <?php
-\Assert\lazy()
+Assert::lazy()
     ->that(10, 'foo')->string()
     ->that(null, 'bar')->notEmpty()
     ->that('string', 'baz')->isArray()

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'PDO');      // 
 ### Assert::that() Chaining
 
 Using the static API on values is very verbose when checking values against multiple assertions.
-Starting with 2.0 of Assert there is a much nicer fluent API for assertions, starting
-with ``Assert::that($value)`` and then receiving the assertions you want to call
+Starting with 2.6.7 of Assert the `Assert` class provides a much nicer fluent API for assertions, starting
+with `Assert::that($value)` and then receiving the assertions you want to call
 on the fluent interface. You only have to specify the `$value` once.
 
 ```php
@@ -96,8 +96,13 @@ Assert::that($value)->nullOr()->string()->startsWith("Foo");
 Assert::that($values)->all()->float();
 ```
 
-There are also two shortcut function ``Assert::thatNullOr()`` and ``Assert::thatAll()`` enabling
+There are also two shortcut function `Assert::thatNullOr()` and `Assert::thatAll()` enabling
 the "nullOr" or "all" helper respectively.
+
+### \Assert\that()
+Previously (starting with version 2.0 of Assert) this fluent interface was provided by the functions
+`\Assert\that()`, `\Assert\thatNullOr()` and `\Assert\thatAll()` respectively. These functions have
+been deprecated in favor of the static methods described above and will be removed in version 3.0 of Assert.
 
 ### Lazy Assertions
 
@@ -129,6 +134,10 @@ On failure ``verifyNow()`` will throw an exception
 
 You can also retrieve all the ``AssertionFailedException``s by calling ``getErrorExceptions()``.
 This can be useful for example to build a failure response for the user.
+
+### \Assert\lazy()
+As with the `Assert` chaining methods lazy assertions were initiated by the function `\Assert\lazy()` that
+has been deprecated since version 2.6.7. As of the release of version 3.0 this function will no longer be available.
 
 ## List of assertions
 

--- a/bin/generate_method_docs.php
+++ b/bin/generate_method_docs.php
@@ -151,7 +151,7 @@ class MethodDocGenerator
                     return false;
                 }
 
-                if (in_array($reflMethod->getName(), array('__construct', '__call'))) {
+                if (in_array($reflMethod->getName(), array('__construct', '__call', 'setAssertionClassName'))) {
                     return false;
                 }
 

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
       "lib/Assert/functions.php"
     ]
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Assert\\Tests\\": "tests/Assert/Tests"
+    }
+  },
   "scripts": {
     "assert:generate-docs": "php bin/generate_method_docs.php",
     "assert:cs-lint": "php-cs-fixer fix --diff --verbose --dry-run",

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -13,7 +13,11 @@
 
 namespace Assert;
 
-if (!function_exists(__NAMESPACE__ . '\that')) {
+/**
+ * AssertionChain factory
+ */
+abstract class Assert
+{
     /**
      * Start validation on a value, returns {@link AssertionChain}
      *
@@ -22,67 +26,57 @@ if (!function_exists(__NAMESPACE__ . '\that')) {
      *
      * @example
      *
-     *  \Assert\that($value)->notEmpty()->integer();
-     *  \Assert\that($value)->nullOr()->string()->startsWith("Foo");
+     *  Assert::that($value)->notEmpty()->integer();
+     *  Assert::that($value)->nullOr()->string()->startsWith("Foo");
      *
      * The assertion chain can be stateful, that means be careful when you reuse
      * it. You should never pass around the chain.
      *
-     * @param mixed  $value
+     * @param mixed $value
      * @param string $defaultMessage
      * @param string $defaultPropertyPath
      *
      * @return \Assert\AssertionChain
-     * @deprecated
      */
-    function that($value, $defaultMessage = null, $defaultPropertyPath = null)
+    public static function that($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return Assert::that($value, $defaultMessage, $defaultPropertyPath);
+        return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
     }
-}
 
-if (!function_exists(__NAMESPACE__ . '\thatAll')) {
     /**
      * Start validation on a set of values, returns {@link AssertionChain}
      *
-     * @param mixed  $values
+     * @param mixed $values
      * @param string $defaultMessage
      * @param string $defaultPropertyPath
      *
      * @return \Assert\AssertionChain
-     * @deprecated
      */
-    function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
+    public static function thatAll($values, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return Assert::that($values, $defaultMessage, $defaultPropertyPath)->all();
+        return static::that($values, $defaultMessage, $defaultPropertyPath)->all();
     }
-}
 
-if (!function_exists(__NAMESPACE__ . '\thatNullOr')) {
     /**
      * Start validation and allow NULL, returns {@link AssertionChain}
      *
-     * @param mixed  $value
+     * @param mixed $value
      * @param string $defaultMessage
      * @param string $defaultPropertyPath
      *
      * @return \Assert\AssertionChain
-     * @deprecated
      */
-    function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
+    public static function thatNullOr($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return Assert::that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
+        return static::that($value, $defaultMessage, $defaultPropertyPath)->nullOr();
     }
-}
 
-if (!function_exists(__NAMESPACE__ . '\lazy')) {
     /**
      * Create a lazy assertion object.
      *
      * @return \Assert\LazyAssertion
-     * @deprecated
      */
-    function lazy()
+    public static function lazy()
     {
         return new LazyAssertion();
     }

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -21,6 +21,9 @@ abstract class Assert
     /** @var string */
     protected static $lazyAssertionExceptionClass = LazyAssertionException::class;
 
+    /** @var string */
+    protected static $assertionClass = Assertion::class;
+
     /**
      * Start validation on a value, returns {@link AssertionChain}
      *
@@ -43,7 +46,9 @@ abstract class Assert
      */
     public static function that($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+        return (new AssertionChain($value, $defaultMessage, $defaultPropertyPath))
+            ->setAssertionClassName(static::$assertionClass)
+        ;
     }
 
     /**

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -46,7 +46,8 @@ abstract class Assert
      */
     public static function that($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
-        return (new AssertionChain($value, $defaultMessage, $defaultPropertyPath))
+        $assertionChain = new AssertionChain($value, $defaultMessage, $defaultPropertyPath);
+        return $assertionChain
             ->setAssertionClassName(static::$assertionClass)
         ;
     }
@@ -86,7 +87,8 @@ abstract class Assert
      */
     public static function lazy()
     {
-        return (new LazyAssertion())
+        $lazyAssertion = new LazyAssertion();
+        return $lazyAssertion
             ->setExceptionClass(static::$lazyAssertionExceptionClass)
         ;
     }

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -18,6 +18,9 @@ namespace Assert;
  */
 abstract class Assert
 {
+    /** @var string */
+    protected static $lazyAssertionExceptionClass = LazyAssertionException::class;
+
     /**
      * Start validation on a value, returns {@link AssertionChain}
      *
@@ -78,6 +81,8 @@ abstract class Assert
      */
     public static function lazy()
     {
-        return new LazyAssertion();
+        return (new LazyAssertion())
+            ->setExceptionClass(static::$lazyAssertionExceptionClass)
+        ;
     }
 }

--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -19,10 +19,10 @@ namespace Assert;
 abstract class Assert
 {
     /** @var string */
-    protected static $lazyAssertionExceptionClass = LazyAssertionException::class;
+    protected static $lazyAssertionExceptionClass = 'Assert\LazyAssertionException';
 
     /** @var string */
-    protected static $assertionClass = Assertion::class;
+    protected static $assertionClass = 'Assert\Assertion';
 
     /**
      * Start validation on a value, returns {@link AssertionChain}

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -116,7 +116,7 @@ class AssertionChain
     private $all = false;
 
     /** @var string|Assertion Class to use for assertion calls */
-    private $assertionClassName = Assertion::class;
+    private $assertionClassName = 'Assert\Assertion';
 
     public function __construct($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
@@ -204,8 +204,8 @@ class AssertionChain
      */
     public function setAssertionClassName($className)
     {
-        if ($className !== Assertion::class && !is_subclass_of($className, Assertion::class)) {
-            throw new LogicException($className . ' is not (a subclass of) ' . Assertion::class);
+        if ($className !== 'Assert\Assertion' && !is_subclass_of($className, 'Assert\Assertion')) {
+            throw new LogicException($className . ' is not (a subclass of) Assert\Assertion');
         }
 
         $this->assertionClassName = $className;

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -204,6 +204,10 @@ class AssertionChain
      */
     public function setAssertionClassName($className)
     {
+        if (!is_string($className)) {
+            throw new LogicException('Exception class name must be passed as a string');
+        }
+
         if ($className !== 'Assert\Assertion' && !is_subclass_of($className, 'Assert\Assertion')) {
             throw new LogicException($className . ' is not (a subclass of) Assert\Assertion');
         }

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -14,6 +14,7 @@
 
 namespace Assert;
 
+use LogicException;
 use ReflectionClass;
 
 /**
@@ -114,6 +115,9 @@ class AssertionChain
      */
     private $all = false;
 
+    /** @var string|Assertion Class to use for assertion calls */
+    private $assertionClassName = Assertion::class;
+
     public function __construct($value, $defaultMessage = null, $defaultPropertyPath = null)
     {
         $this->value = $value;
@@ -135,11 +139,11 @@ class AssertionChain
             return $this;
         }
 
-        if (!method_exists('Assert\Assertion', $methodName)) {
+        if (!method_exists($this->assertionClassName, $methodName)) {
             throw new \RuntimeException("Assertion '" . $methodName . "' does not exist.");
         }
 
-        $reflClass = new ReflectionClass('Assert\Assertion');
+        $reflClass = new ReflectionClass($this->assertionClassName);
         $method = $reflClass->getMethod($methodName);
 
         array_unshift($args, $this->value);
@@ -163,7 +167,7 @@ class AssertionChain
             $methodName = 'all' . $methodName;
         }
 
-        call_user_func_array(array('Assert\Assertion', $methodName), $args);
+        call_user_func_array(array($this->assertionClassName, $methodName), $args);
 
         return $this;
     }
@@ -191,6 +195,20 @@ class AssertionChain
             $this->alwaysValid = true;
         }
 
+        return $this;
+    }
+
+    /**
+     * @param string $className
+     * @return $this
+     */
+    public function setAssertionClassName($className)
+    {
+        if ($className !== Assertion::class && !is_subclass_of($className, Assertion::class)) {
+            throw new LogicException($className . ' is not (a subclass of) ' . Assertion::class);
+        }
+
+        $this->assertionClassName = $className;
         return $this;
     }
 }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -102,7 +102,7 @@ class LazyAssertion
     private $errors = array();
 
     /** @var string|LazyAssertionException The class to use for exceptions */
-    private $exceptionClass = LazyAssertionException::class;
+    private $exceptionClass = 'Assert\LazyAssertionException';
 
     public function that($value, $propertyPath, $defaultMessage = null)
     {
@@ -147,8 +147,8 @@ class LazyAssertion
      */
     public function setExceptionClass($className)
     {
-        if ($className !== LazyAssertionException::class && !is_subclass_of($className, LazyAssertionException::class)) {
-            throw new LogicException($className . ' is not (a subclass of) ' . LazyAssertionException::class);
+        if ($className !== 'Assert\LazyAssertionException' && !is_subclass_of($className, 'Assert\LazyAssertionException')) {
+            throw new LogicException($className . ' is not (a subclass of) Assert\LazyAssertionException');
         }
 
         $this->exceptionClass = $className;

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -102,7 +102,7 @@ class LazyAssertion
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
-        $this->currentChain = \Assert\that($value, $defaultMessage, $propertyPath);
+        $this->currentChain = Assert::that($value, $defaultMessage, $propertyPath);
 
         return $this;
     }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -147,6 +147,10 @@ class LazyAssertion
      */
     public function setExceptionClass($className)
     {
+        if (!is_string($className)) {
+            throw new LogicException('Exception class name must be passed as a string');
+        }
+
         if ($className !== 'Assert\LazyAssertionException' && !is_subclass_of($className, 'Assert\LazyAssertionException')) {
             throw new LogicException($className . ' is not (a subclass of) Assert\LazyAssertionException');
         }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -13,6 +13,8 @@
 
 namespace Assert;
 
+use LogicException;
+
 /**
  * Chaining builder for lazy assertions
  *
@@ -99,6 +101,9 @@ class LazyAssertion
     private $currentChain;
     private $errors = array();
 
+    /** @var string|LazyAssertionException The class to use for exceptions */
+    private $exceptionClass = LazyAssertionException::class;
+
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
@@ -130,9 +135,23 @@ class LazyAssertion
     public function verifyNow()
     {
         if ($this->errors) {
-            throw LazyAssertionException::fromErrors($this->errors);
+            throw call_user_func([$this->exceptionClass, 'fromErrors'], $this->errors);
         }
 
         return true;
+    }
+
+    /**
+     * @param string $className
+     * @return $this
+     */
+    public function setExceptionClass($className)
+    {
+        if ($className !== LazyAssertionException::class && !is_subclass_of($className, LazyAssertionException::class)) {
+            throw new LogicException($className . ' is not (a subclass of) ' . LazyAssertionException::class);
+        }
+
+        $this->exceptionClass = $className;
+        return $this;
     }
 }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -135,7 +135,7 @@ class LazyAssertion
     public function verifyNow()
     {
         if ($this->errors) {
-            throw call_user_func([$this->exceptionClass, 'fromErrors'], $this->errors);
+            throw call_user_func(array($this->exceptionClass, 'fromErrors'), $this->errors);
         }
 
         return true;

--- a/lib/Assert/LazyAssertionException.php
+++ b/lib/Assert/LazyAssertionException.php
@@ -33,7 +33,7 @@ class LazyAssertionException extends \InvalidArgumentException
             $message .= sprintf("%d) %s: %s\n", $i++, $error->getPropertyPath(), $error->getMessage());
         }
 
-        return new self($message, $errors);
+        return new static($message, $errors);
     }
 
     public function __construct($message, array $errors)

--- a/tests/Assert/Tests/AssertionChainFunctionsTest.php
+++ b/tests/Assert/Tests/AssertionChainFunctionsTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+/**
+ * Test case specific for the deprecated functions creating assertion chains
+ */
+class AssertionChainFunctionsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_chains_assertions()
+    {
+        \Assert\that(10)->notEmpty()->integer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_shifts_arguments_to_assertions_by_one()
+    {
+        \Assert\that(10)->eq(10);
+    }
+
+    /**
+     * @test
+     */
+    public function it_knowns_default_error_message()
+    {
+        $this->setExpectedException('Assert\InvalidArgumentException', 'Not Null and such');
+
+        \Assert\that(null, 'Not Null and such')->notEmpty();
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_assertions_on_valid_null()
+    {
+        \Assert\that(null)->nullOr()->integer()->eq(10);
+    }
+
+    /**
+     * @test
+     */
+    public function it_validates_all_inputs()
+    {
+        \Assert\that(array(1, 2, 3))->all()->integer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_thatall_shortcut()
+    {
+        \Assert\thatAll(array(1, 2, 3))->integer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_nullor_shortcut()
+    {
+        \Assert\thatNullOr(null)->integer()->eq(10);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Assertion 'unknownAssertion' does not exist.
+     * @test
+     */
+    public function it_throws_exception_for_unknown_assertion()
+    {
+        \Assert\that(null)->unknownAssertion();
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_satisfy_shortcut()
+    {
+        \Assert\that(null)->satisfy(function ($value) {
+            return is_null($value);
+        });
+    }
+}

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -14,6 +14,7 @@
 namespace Assert\Tests;
 
 use Assert\Assert;
+use Assert\AssertionChain;
 
 class AssertionChainTest extends \PHPUnit_Framework_TestCase
 {
@@ -93,5 +94,43 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
         Assert::that(null)->satisfy(function ($value) {
             return is_null($value);
         });
+    }
+
+    public function testThatCustomAssertionClassIsUsedWhenSet()
+    {
+        $assertionChain = new AssertionChain('foo');
+        $assertionChain->setAssertionClassName('Assert\Tests\CustomAssertion');
+
+        CustomAssertion::clearCalls();
+        $message = uniqid();
+        $assertionChain->string($message);
+
+        $this->assertSame(array(array('string', 'foo')), CustomAssertion::getCalls());
+    }
+
+    /**
+     * @dataProvider provideDataToTestThatSetAssertionClassNameWillNotAcceptInvalidAssertionClasses
+     * @param $assertionClassName
+     */
+    public function testThatSetAssertionClassNameWillNotAcceptInvalidAssertionClasses($assertionClassName)
+    {
+        $lazyAssertion = new AssertionChain('foo');
+
+        $this->setExpectedException('LogicException');
+        $lazyAssertion->setAssertionClassName($assertionClassName);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideDataToTestThatSetAssertionClassNameWillNotAcceptInvalidAssertionClasses()
+    {
+        return [
+            'null' => [null],
+            'string' => ['foo'],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+            'other class' => [__CLASS__],
+        ];
     }
 }

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -13,6 +13,8 @@
 
 namespace Assert\Tests;
 
+use Assert\Assert;
+
 class AssertionChainTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -20,7 +22,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_chains_assertions()
     {
-        \Assert\that(10)->notEmpty()->integer();
+        Assert::that(10)->notEmpty()->integer();
     }
 
     /**
@@ -28,7 +30,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_shifts_arguments_to_assertions_by_one()
     {
-        \Assert\that(10)->eq(10);
+        Assert::that(10)->eq(10);
     }
 
     /**
@@ -38,7 +40,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Assert\InvalidArgumentException', 'Not Null and such');
 
-        \Assert\that(null, 'Not Null and such')->notEmpty();
+        Assert::that(null, 'Not Null and such')->notEmpty();
     }
 
     /**
@@ -46,7 +48,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_skips_assertions_on_valid_null()
     {
-        \Assert\that(null)->nullOr()->integer()->eq(10);
+        Assert::that(null)->nullOr()->integer()->eq(10);
     }
 
     /**
@@ -54,7 +56,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_validates_all_inputs()
     {
-        \Assert\that(array(1, 2, 3))->all()->integer();
+        Assert::that(array(1, 2, 3))->all()->integer();
     }
 
     /**
@@ -62,7 +64,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_thatall_shortcut()
     {
-        \Assert\thatAll(array(1, 2, 3))->integer();
+        Assert::thatAll(array(1, 2, 3))->integer();
     }
 
     /**
@@ -70,7 +72,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_nullor_shortcut()
     {
-        \Assert\thatNullOr(null)->integer()->eq(10);
+        Assert::thatNullOr(null)->integer()->eq(10);
     }
 
     /**
@@ -80,7 +82,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_throws_exception_for_unknown_assertion()
     {
-        \Assert\that(null)->unknownAssertion();
+        Assert::that(null)->unknownAssertion();
     }
 
     /**
@@ -88,7 +90,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function it_has_satisfy_shortcut()
     {
-        \Assert\that(null)->satisfy(function ($value) {
+        Assert::that(null)->satisfy(function ($value) {
             return is_null($value);
         });
     }

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -125,12 +125,12 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
      */
     public function provideDataToTestThatSetAssertionClassNameWillNotAcceptInvalidAssertionClasses()
     {
-        return [
+        return array(
             'null' => array(null),
             'string' => array('foo'),
             'array' => array(array()),
             'object' => array(new \stdClass()),
             'other class' => array(__CLASS__),
-        ];
+        );
     }
 }

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -126,11 +126,11 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
     public function provideDataToTestThatSetAssertionClassNameWillNotAcceptInvalidAssertionClasses()
     {
         return [
-            'null' => [null],
-            'string' => ['foo'],
-            'array' => [[]],
-            'object' => [new \stdClass()],
-            'other class' => [__CLASS__],
+            'null' => array(null),
+            'string' => array('foo'),
+            'array' => array(array()),
+            'object' => array(new \stdClass()),
+            'other class' => array(__CLASS__),
         ];
     }
 }

--- a/tests/Assert/Tests/CustomAssertion.php
+++ b/tests/Assert/Tests/CustomAssertion.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+use Assert\Assertion;
+
+class CustomAssertion extends Assertion
+{
+    protected static $exceptionClass = 'Assert\Tests\CustomException';
+    private static $calls = array();
+
+    public static function clearCalls()
+    {
+        self::$calls = array();
+    }
+
+    public static function getCalls()
+    {
+        return self::$calls;
+    }
+
+    public static function string($value, $message = null, $propertyPath = null)
+    {
+        self::$calls[] = array('string', $value);
+        return parent::string($value, $message, $propertyPath);
+    }
+}

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -30,7 +30,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function it_uses_custom_exception_class()
     {
-        $this->expectException(CustomException::class);
+        $this->setExpectedException(CustomException::class);
         CustomAssertion::integer('foo');
     }
 
@@ -43,7 +43,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
         CustomAssert::that($string)->string();
         $this->assertSame([['string', $string]], CustomAssertion::getCalls());
 
-        $this->expectException(CustomException::class);
+        $this->setExpectedException(CustomException::class);
         CustomAssert::that($string)->integer();
     }
 
@@ -52,7 +52,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function it_uses_custom_exception_for_lazy_assertion_chains()
     {
-        $this->expectException(CustomLazyAssertionException::class);
+        $this->setExpectedException(CustomLazyAssertionException::class);
         CustomAssert::lazy()
             ->that('foo', 'foo')->integer()
             ->verifyNow()
@@ -64,7 +64,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function it_uses_custom_exception_for_lazy_assertion_chains_when_first_assertion_does_not_fail()
     {
-        $this->expectException(CustomLazyAssertionException::class);
+        $this->setExpectedException(CustomLazyAssertionException::class);
         CustomAssert::lazy()
             ->that('foo', 'foo')->string()
             ->that('bar', 'bar')->integer()

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -30,7 +30,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function it_uses_custom_exception_class()
     {
-        $this->setExpectedException(CustomException::class);
+        $this->setExpectedException('Assert\Tests\CustomException');
         CustomAssertion::integer('foo');
     }
 
@@ -43,7 +43,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
         CustomAssert::that($string)->string();
         $this->assertSame([['string', $string]], CustomAssertion::getCalls());
 
-        $this->setExpectedException(CustomException::class);
+        $this->setExpectedException('Assert\Tests\CustomException');
         CustomAssert::that($string)->integer();
     }
 
@@ -52,7 +52,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function it_uses_custom_exception_for_lazy_assertion_chains()
     {
-        $this->setExpectedException(CustomLazyAssertionException::class);
+        $this->setExpectedException('Assert\Tests\CustomLazyAssertionException');
         CustomAssert::lazy()
             ->that('foo', 'foo')->integer()
             ->verifyNow()
@@ -64,7 +64,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function it_uses_custom_exception_for_lazy_assertion_chains_when_first_assertion_does_not_fail()
     {
-        $this->setExpectedException(CustomLazyAssertionException::class);
+        $this->setExpectedException('Assert\Tests\CustomLazyAssertionException');
         CustomAssert::lazy()
             ->that('foo', 'foo')->string()
             ->that('bar', 'bar')->integer()
@@ -83,7 +83,7 @@ class CustomLazyAssertionException extends LazyAssertionException
 
 class CustomAssertion extends Assertion
 {
-    protected static $exceptionClass = CustomException::class;
+    protected static $exceptionClass = 'Assert\Tests\CustomException';
     private static $calls = [];
 
     public static function clearCalls()
@@ -105,6 +105,6 @@ class CustomAssertion extends Assertion
 
 class CustomAssert extends Assert
 {
-    protected static $assertionClass = CustomAssertion::class;
-    protected static $lazyAssertionExceptionClass = CustomLazyAssertionException::class;
+    protected static $assertionClass = 'Assert\Tests\CustomAssertion';
+    protected static $lazyAssertionExceptionClass = 'Assert\Tests\CustomLazyAssertionException';
 }

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -14,7 +14,6 @@
 namespace Assert\Tests;
 
 use Assert\Assert;
-use Assert\Assertion;
 use Assert\InvalidArgumentException;
 
 class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
@@ -74,28 +73,6 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
 
 class CustomException extends InvalidArgumentException
 {
-}
-
-class CustomAssertion extends Assertion
-{
-    protected static $exceptionClass = 'Assert\Tests\CustomException';
-    private static $calls = array();
-
-    public static function clearCalls()
-    {
-        self::$calls = array();
-    }
-
-    public static function getCalls()
-    {
-        return self::$calls;
-    }
-
-    public static function string($value, $message = null, $propertyPath = null)
-    {
-        self::$calls[] = array('string', $value);
-        return parent::string($value, $message, $propertyPath);
-    }
 }
 
 class CustomAssert extends Assert

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -41,7 +41,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
     {
         $string = 's' . uniqid();
         CustomAssert::that($string)->string();
-        $this->assertSame([['string', $string]], CustomAssertion::getCalls());
+        $this->assertSame(array(array('string', $string)), CustomAssertion::getCalls());
 
         $this->setExpectedException('Assert\Tests\CustomException');
         CustomAssert::that($string)->integer();
@@ -84,11 +84,11 @@ class CustomLazyAssertionException extends LazyAssertionException
 class CustomAssertion extends Assertion
 {
     protected static $exceptionClass = 'Assert\Tests\CustomException';
-    private static $calls = [];
+    private static $calls = array();
 
     public static function clearCalls()
     {
-        self::$calls = [];
+        self::$calls = array();
     }
 
     public static function getCalls()
@@ -98,7 +98,7 @@ class CustomAssertion extends Assertion
 
     public static function string($value, $message = null, $propertyPath = null)
     {
-        self::$calls[] = ['string', $value];
+        self::$calls[] = array('string', $value);
         return parent::string($value, $message, $propertyPath);
     }
 }

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -69,6 +69,47 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
             ->verifyNow()
         ;
     }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_for_lazy_assertion_chains_that_try_all_assertions_per_chain()
+    {
+        $this->setExpectedException('Assert\Tests\CustomLazyAssertionException', <<< MESSAGE
+The following 4 assertions failed:
+1) foo: Value "foo" is not an integer.
+2) foo: Value "foo" is not an array.
+3) bar: Value "123" expected to be string, type integer given.
+4) bar: Value "123" is not an array.
+MESSAGE
+);
+        CustomAssert::lazy()
+            ->that('foo', 'foo')->tryAll()->integer()->isArray()
+            ->that(123, 'bar')->tryAll()->string()->isArray()
+            ->verifyNow()
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_for_lazy_assertion_chains_that_try_all_assertions()
+    {
+        $this->setExpectedException('Assert\Tests\CustomLazyAssertionException', <<< MESSAGE
+The following 4 assertions failed:
+1) foo: Value "foo" is not an integer.
+2) foo: Value "foo" is not an array.
+3) bar: Value "123" expected to be string, type integer given.
+4) bar: Value "123" is not an array.
+MESSAGE
+);
+        CustomAssert::lazy()
+            ->tryAll()
+            ->that('foo', 'foo')->integer()->isArray()
+            ->that(123, 'bar')->string()->isArray()
+            ->verifyNow()
+        ;
+    }
 }
 
 class CustomException extends InvalidArgumentException

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -16,7 +16,6 @@ namespace Assert\Tests;
 use Assert\Assert;
 use Assert\Assertion;
 use Assert\InvalidArgumentException;
-use Assert\LazyAssertionException;
 
 class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
 {
@@ -74,10 +73,6 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
 }
 
 class CustomException extends InvalidArgumentException
-{
-}
-
-class CustomLazyAssertionException extends LazyAssertionException
 {
 }
 

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+use Assert\Assert;
+use Assert\Assertion;
+use Assert\InvalidArgumentException;
+use Assert\LazyAssertionException;
+
+class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        CustomAssertion::clearCalls();
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_class()
+    {
+        $this->expectException(CustomException::class);
+        CustomAssertion::integer('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_assertion_class_for_assertion_chains()
+    {
+        $string = 's' . uniqid();
+        CustomAssert::that($string)->string();
+        $this->assertSame([['string', $string]], CustomAssertion::getCalls());
+
+        $this->expectException(CustomException::class);
+        CustomAssert::that($string)->integer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_for_lazy_assertion_chains()
+    {
+        $this->expectException(CustomLazyAssertionException::class);
+        CustomAssert::lazy()
+            ->that('foo', 'foo')->integer()
+            ->verifyNow()
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_custom_exception_for_lazy_assertion_chains_when_first_assertion_does_not_fail()
+    {
+        $this->expectException(CustomLazyAssertionException::class);
+        CustomAssert::lazy()
+            ->that('foo', 'foo')->string()
+            ->that('bar', 'bar')->integer()
+            ->verifyNow()
+        ;
+    }
+}
+
+class CustomException extends InvalidArgumentException
+{
+}
+
+class CustomLazyAssertionException extends LazyAssertionException
+{
+}
+
+class CustomAssertion extends Assertion
+{
+    protected static $exceptionClass = CustomException::class;
+    private static $calls = [];
+
+    public static function clearCalls()
+    {
+        self::$calls = [];
+    }
+
+    public static function getCalls()
+    {
+        return self::$calls;
+    }
+
+    public static function string($value, $message = null, $propertyPath = null)
+    {
+        self::$calls[] = ['string', $value];
+        return parent::string($value, $message, $propertyPath);
+    }
+}
+
+class CustomAssert extends Assert
+{
+    protected static $assertionClass = CustomAssertion::class;
+    protected static $lazyAssertionExceptionClass = CustomLazyAssertionException::class;
+}

--- a/tests/Assert/Tests/CustomLazyAssertionException.php
+++ b/tests/Assert/Tests/CustomLazyAssertionException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+use Assert\LazyAssertionException;
+
+class CustomLazyAssertionException extends LazyAssertionException
+{
+}

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -2,6 +2,7 @@
 
 namespace Assert\Tests;
 
+use Assert\Assert;
 use Assert\LazyAssertionException;
 
 class LazyAssertionTest extends \PHPUnit_Framework_TestCase
@@ -20,7 +21,7 @@ The following 3 assertions failed:
 EXC
         );
 
-        \Assert\lazy()
+        Assert::lazy()
             ->that(10, 'foo')->string()
             ->that(null, 'bar')->notEmpty()
             ->that('string', 'baz')->isArray()
@@ -39,7 +40,7 @@ The following 1 assertions failed:
 EXC
         );
 
-        \Assert\lazy()
+        Assert::lazy()
             ->that(null, 'foo')->notEmpty()->string()
             ->verifyNow();
     }
@@ -47,7 +48,7 @@ EXC
     public function testLazyAssertionExceptionCanReturnAllErrors()
     {
         try {
-            \Assert\lazy()
+            Assert::lazy()
                 ->that(10, 'foo')->string()
                 ->that(null, 'bar')->notEmpty()
                 ->that('string', 'baz')->isArray()
@@ -66,7 +67,7 @@ EXC
     public function testVerifyNowReturnsTrueIfAssertionsPass()
     {
         $this->assertTrue(
-            \Assert\lazy()
+            Assert::lazy()
                 ->that(2, 'Two')->eq(2)
                 ->verifyNow()
         );

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -169,12 +169,12 @@ EXC
     public function provideDataToTestThatSetExceptionClassWillNotAcceptInvalidExceptionClasses()
     {
         return [
-            'null' => [null],
-            'string' => ['foo'],
-            'array' => [[]],
-            'object' => [new \stdClass()],
-            'other class' => [__CLASS__],
-            'other exception' => ['Exception'],
+            'null' => array(null),
+            'string' => array('foo'),
+            'array' => array(array()),
+            'object' => array(new \stdClass()),
+            'other class' => array(__CLASS__),
+            'other exception' => array('Exception'),
         ];
     }
 }

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -168,13 +168,13 @@ EXC
      */
     public function provideDataToTestThatSetExceptionClassWillNotAcceptInvalidExceptionClasses()
     {
-        return [
+        return array(
             'null' => array(null),
             'string' => array('foo'),
             'array' => array(array()),
             'object' => array(new \stdClass()),
             'other class' => array(__CLASS__),
             'other exception' => array('Exception'),
-        ];
+        );
     }
 }

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -3,6 +3,7 @@
 namespace Assert\Tests;
 
 use Assert\Assert;
+use Assert\LazyAssertion;
 use Assert\LazyAssertionException;
 
 class LazyAssertionTest extends \PHPUnit_Framework_TestCase
@@ -71,5 +72,44 @@ EXC
                 ->that(2, 'Two')->eq(2)
                 ->verifyNow()
         );
+    }
+
+    public function testThatLazyAssertionThrowsCustomExceptionWhenSet()
+    {
+        $lazyAssertion = new LazyAssertion();
+        $lazyAssertion->setExceptionClass('Assert\Tests\CustomLazyAssertionException');
+
+        $this->setExpectedException('Assert\Tests\CustomLazyAssertionException');
+        $lazyAssertion
+            ->that('foo', 'property')->integer()
+            ->verifyNow()
+        ;
+    }
+
+    /**
+     * @dataProvider provideDataToTestThatSetExceptionClassWillNotAcceptInvalidExceptionClasses
+     * @param mixed $exceptionClass
+     */
+    public function testThatSetExceptionClassWillNotAcceptInvalidExceptionClasses($exceptionClass)
+    {
+        $lazyAssertion = new LazyAssertion();
+
+        $this->setExpectedException('LogicException');
+        $lazyAssertion->setExceptionClass($exceptionClass);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideDataToTestThatSetExceptionClassWillNotAcceptInvalidExceptionClasses()
+    {
+        return [
+            'null' => [null],
+            'string' => ['foo'],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+            'other class' => [__CLASS__],
+            'other exception' => ['Exception'],
+        ];
     }
 }


### PR DESCRIPTION
The functions in the Assert namespace can not be autoloaded, nor can they be used with alternative exception classes. This pull request resolves these issues by introducing a static factory class (\Assert\Assert) that provides these functions as static methods. This will also solve beberlei/assert#57.