### PR TITLE
Test that $skipParameterTest is a valid callable

### DIFF
--- a/bin/generate_method_docs.php
+++ b/bin/generate_method_docs.php
@@ -26,7 +26,7 @@ class MethodDocGenerator
             $parameters = array();
 
             foreach ($method->getParameters() as $methodParameter) {
-                if ($skipParameterTest($methodParameter)) {
+                if (is_callable($skipParameterTest) && call_user_func($skipParameterTest, $methodParameter)) {
                     continue;
                 }
 


### PR DESCRIPTION
The builds that are ran on php 7 fail on the $skipParametersTest variable not being a valid callback `Function name must be a string in /home/travis/build/beberlei/assert/bin/generate_method_docs.php:29`.