### PR TITLE
Added ability to capture multiple errors on a single value in a chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,34 +82,34 @@ Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'stdClass'); // 
 Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'PDO');      // exception
 ```
 
-### Assert::that() Chaining
+### \Assert\that() Chaining
 
 Using the static API on values is very verbose when checking values against multiple assertions.
 Starting with 2.0 of Assert there is a much nicer fluent API for assertions, starting
-with ``Assert::that($value)`` and then receiving the assertions you want to call
+with ``\Assert\that($value)`` and then receiving the assertions you want to call
 on the fluent interface. You only have to specify the `$value` once.
 
 ```php
 <?php
-Assert::that($value)->notEmpty()->integer();
-Assert::that($value)->nullOr()->string()->startsWith("Foo");
-Assert::that($values)->all()->float();
+\Assert\that($value)->notEmpty()->integer();
+\Assert\that($value)->nullOr()->string()->startsWith("Foo");
+\Assert\that($values)->all()->float();
 ```
 
-There are also two shortcut function ``Assert::thatNullOr()`` and ``Assert::thatAll()`` enabling
+There are also two shortcut function ``\Assert\thatNullOr()`` and ``\Assert\thatAll()`` enabling
 the "nullOr" or "all" helper respectively.
 
 ### Lazy Assertions
 
 There are many cases in web development, especially when involving forms, you want to collect several errors
 instead of aborting directly on the first error. This is what lazy assertions are for. Their API
-works exactly like the fluent ``Assert::that()`` API, but instead of throwing an Exception directly,
+works exactly like the fluent ``\Assert\that()`` API, but instead of throwing an Exception directly,
 they collect all errors and only trigger the exception when the method
 ``verifyNow()`` is called on the ``Assert\SoftAssertion`` object.
 
 ```php
 <?php
-Assert::lazy()
+\Assert\lazy()
     ->that(10, 'foo')->string()
     ->that(null, 'bar')->notEmpty()
     ->that('string', 'baz')->isArray()

--- a/README.md
+++ b/README.md
@@ -82,34 +82,34 @@ Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'stdClass'); // 
 Assertion::allIsInstanceOf(array(new \stdClass, new \stdClass), 'PDO');      // exception
 ```
 
-### \Assert\that() Chaining
+### Assert::that() Chaining
 
 Using the static API on values is very verbose when checking values against multiple assertions.
 Starting with 2.0 of Assert there is a much nicer fluent API for assertions, starting
-with ``\Assert\that($value)`` and then receiving the assertions you want to call
+with ``Assert::that($value)`` and then receiving the assertions you want to call
 on the fluent interface. You only have to specify the `$value` once.
 
 ```php
 <?php
-\Assert\that($value)->notEmpty()->integer();
-\Assert\that($value)->nullOr()->string()->startsWith("Foo");
-\Assert\that($values)->all()->float();
+Assert::that($value)->notEmpty()->integer();
+Assert::that($value)->nullOr()->string()->startsWith("Foo");
+Assert::that($values)->all()->float();
 ```
 
-There are also two shortcut function ``\Assert\thatNullOr()`` and ``\Assert\thatAll()`` enabling
+There are also two shortcut function ``Assert::thatNullOr()`` and ``Assert::thatAll()`` enabling
 the "nullOr" or "all" helper respectively.
 
 ### Lazy Assertions
 
 There are many cases in web development, especially when involving forms, you want to collect several errors
 instead of aborting directly on the first error. This is what lazy assertions are for. Their API
-works exactly like the fluent ``\Assert\that()`` API, but instead of throwing an Exception directly,
+works exactly like the fluent ``Assert::that()`` API, but instead of throwing an Exception directly,
 they collect all errors and only trigger the exception when the method
 ``verifyNow()`` is called on the ``Assert\SoftAssertion`` object.
 
 ```php
 <?php
-\Assert\lazy()
+Assert::lazy()
     ->that(10, 'foo')->string()
     ->that(null, 'bar')->notEmpty()
     ->that('string', 'baz')->isArray()
@@ -141,7 +141,9 @@ capture all of the resulting failed assertion error messages. Here's an example:
     ->verifyAll();
 ```
 
-The above shows how to use this functionality to finely tune the behavior of reporting failures, but to make catching all failures even easier, you may also call ``tryAll`` before making any assertions like below. This helps to reduce method calls, and has the same behavior as above.
+The above shows how to use this functionality to finely tune the behavior of reporting failures, but to make 
+catching all failures even easier, you may also call ``tryAll`` before making any assertions like below. This 
+helps to reduce method calls, and has the same behavior as above.
 
 ```php
 \Assert\lazy()->tryAll()

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ On failure ``verifyNow()`` will throw an exception
 You can also retrieve all the ``AssertionFailedException``s by calling ``getErrorExceptions()``.
 This can be useful for example to build a failure response for the user.
 
+For those looking to capture multiple errors on a single value when using a lazy assertion chain,
+you may follow your call to ``that`` with ``tryAll`` to run all assertions against the value, and
+capture all of the resulting failed assertion error messages. Here's an example:
+
+```php
+\Assert\lazy()
+    ->that(10, 'foo')->tryAll()->integer()->between(5, 15)
+    ->verifyAll();
+```
+
 ## List of assertions
 
 ```php

--- a/README.md
+++ b/README.md
@@ -137,7 +137,17 @@ capture all of the resulting failed assertion error messages. Here's an example:
 ```php
 \Assert\lazy()
     ->that(10, 'foo')->tryAll()->integer()->between(5, 15)
+    ->that(null, 'foo')->tryAll()->notEmpty()->string()
     ->verifyAll();
+```
+
+The above shows how to use this functionality to finely tune the behavior of reporting failures, but to make catching all failures even easier, you may also call ``tryAll`` before making any assertions like below. This helps to reduce method calls, and has the same behavior as above.
+
+```php
+\Assert\lazy()->tryAll()
+    ->that(10, 'foo')->integer()->between(5, 15)
+    ->that(null, 'foo')->notEmpty()->string()
+    ->verifyNow();
 ```
 
 ## List of assertions

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -96,14 +96,15 @@ namespace Assert;
 class LazyAssertion
 {
     private $currentChainFailed = false;
-    private $shouldTryAll = false;
+    private $alwaysTryAll = false;
+    private $thisChainTryAll = false;
     private $currentChain;
     private $errors = array();
 
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
-        $this->shouldTryAll = false;
+        $this->thisChainTryAll = false;
         $this->currentChain = \Assert\that($value, $defaultMessage, $propertyPath);
 
         return $this;
@@ -111,13 +112,21 @@ class LazyAssertion
 
     public function tryAll()
     {
-        $this->shouldTryAll = true;
+        if (!$this->currentChain) {
+            $this->alwaysTryAll = true;
+        }
+
+        $this->thisChainTryAll = true;
+
         return $this;
     }
 
     public function __call($method, $args)
     {
-        if ($this->shouldTryAll === false && $this->currentChainFailed === true) {
+        if ($this->alwaysTryAll === false
+            && $this->thisChainTryAll === false
+            && $this->currentChainFailed === true
+        ) {
             return $this;
         }
 

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -96,20 +96,28 @@ namespace Assert;
 class LazyAssertion
 {
     private $currentChainFailed = false;
+    private $shouldTryAll = false;
     private $currentChain;
     private $errors = array();
 
     public function that($value, $propertyPath, $defaultMessage = null)
     {
         $this->currentChainFailed = false;
+        $this->shouldTryAll = false;
         $this->currentChain = \Assert\that($value, $defaultMessage, $propertyPath);
 
         return $this;
     }
 
+    public function tryAll()
+    {
+        $this->shouldTryAll = true;
+        return $this;
+    }
+
     public function __call($method, $args)
     {
-        if ($this->currentChainFailed === true) {
+        if ($this->shouldTryAll === false && $this->currentChainFailed === true) {
             return $this;
         }
 

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -119,4 +119,21 @@ EXC
             ->that(null, 'foo')->tryAll()->notEmpty()->string()
             ->verifyNow();
     }
+
+    public function testCallsToTryAllOnLazyAlwaysReportAllGetReported()
+    {
+        $this->setExpectedException('\Assert\LazyAssertionException', <<<EXC
+The following 4 assertions failed:
+1) foo: Value "10" is not a float.
+2) foo: Provided "10" is not greater than "100".
+3) foo: Value "<NULL>" is empty, but non empty value was expected.
+4) foo: Value "<NULL>" expected to be string, type NULL given.
+
+EXC
+);
+        \Assert\lazy()->tryAll()
+            ->that(10, 'foo')->float()->greaterThan(100)
+            ->that(null, 'foo')->notEmpty()->string()
+            ->verifyNow();
+    }
 }

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -102,4 +102,21 @@ EXC
             ->that(null, 'foo')->notEmpty()->string()
             ->verifyNow();
     }
+
+    public function testCallsToThatWithTryAllWithMultipleAssertionsAllGetReported()
+    {
+        $this->setExpectedException('\Assert\LazyAssertionException', <<<EXC
+The following 4 assertions failed:
+1) foo: Value "10" is not a float.
+2) foo: Provided "10" is not greater than "100".
+3) foo: Value "<NULL>" is empty, but non empty value was expected.
+4) foo: Value "<NULL>" expected to be string, type NULL given.
+
+EXC
+);
+        \Assert\lazy()
+            ->that(10, 'foo')->tryAll()->float()->greaterThan(100)
+            ->that(null, 'foo')->tryAll()->notEmpty()->string()
+            ->verifyNow();
+    }
 }

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -71,4 +71,35 @@ EXC
                 ->verifyNow()
         );
     }
+
+    public function testRestOfChainNotSkippedWhenTryAllUsed()
+    {
+        try {
+            \Assert\lazy()
+                ->that(9.9, 'foo')->tryAll()->integer('must be int')->between(10, 20, 'must be between')
+                ->verifyNow();
+        } catch (LazyAssertionException $ex) {
+            $this->assertEquals(array(
+                'must be int',
+                'must be between'
+            ), array_map(function (\Exception $ex) {
+                return $ex->getMessage();
+            }, $ex->getErrorExceptions()));
+        }
+    }
+
+    public function testCallsToThatFollowingTryAllSkipAssertionsAfterFailure()
+    {
+        $this->setExpectedException('Assert\LazyAssertionException', <<<EXC
+The following 1 assertions failed:
+1) foo: Value "<NULL>" is empty, but non empty value was expected.
+
+EXC
+        );
+
+        \Assert\lazy()
+            ->that(10, 'foo')->tryAll()->integer()
+            ->that(null, 'foo')->notEmpty()->string()
+            ->verifyNow();
+    }
 }


### PR DESCRIPTION
Using the existing `LazyAssertion` implementation, I found in cumbersome to capture multiple assertion failure messages pertaining to a single value. With this feature, I hope that this will be alleviated.

The purpose of the feature is to allow one to capture multiple assertion failures per value by dictating the behavior of the `LazyAssertion` class via special method call; the method is `tryAll`. What it will do specifically for this feature is, it will set a flag to keep the assertion chain going even after a failure is detected with a previous assertion.

This behavior can already be achieved, however it is necessary to call `that` multiple times, and this leads to multiple `AssertionChain` objects being created. For the sake of writing cleaner code and using resources more effectively, I felt this would be a worthwhile feature to propose.

Here is a list of exactly what I have included in this pull request:

- Added `tryAll` method to `\Assert\LazyAssertion`
- Added appropriate unit tests
- Updated the documentation