### PR TITLE
Update to php-cs-fixer ^2.0 release

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,6 +12,5 @@ $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 
 return PhpCsFixer\Config::create()
     ->setRules($rules)
-    ->finder($finder)
-    ->setUsingCache(true)
+    ->setFinder($finder)
     ->setCacheFile($cacheDir . '/.php_cs.cache');

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ env:
 
 matrix:
   include:
-    - php: hhvm
+    - php: hhvm-3.9
+      sudo: required
+      dist: trusty
+      group: edge
     - php: nightly
     - php: 7.1
     - php: 7.0

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "2.0.0-alpha",
-    "phpunit/phpunit": "@stable"
+    "phpunit/phpunit": "@stable",
+    "friendsofphp/php-cs-fixer": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
PHP CS Fixer `2.0.0` was released today.