### PR TITLE
add assertion that a constant is defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Assertion::classExists($value);
 Assertion::contains($string, $needle);
 Assertion::count($countable, $count);
 Assertion::date($value, $format);
+Assertion::defined($constant);
 Assertion::digit($value);
 Assertion::directory($value);
 Assertion::e164($value);

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -31,6 +31,7 @@ use BadMethodCallException;
  * @method static bool allContains($string, $needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string contains a sequence of chars for all values.
  * @method static bool allCount($countable, $count, $message = null, $propertyPath = null) Assert that the count of countable is equal to count for all values.
  * @method static bool allDate($value, $format, $message = null, $propertyPath = null) Assert that date is valid and corresponds to the given format for all values.
+ * @method static bool allDefined($constant, $message = null, $propertyPath = null) Assert that a constant is defined for all values.
  * @method static bool allDigit($value, $message = null, $propertyPath = null) Validates if an integer or integerish is a digit for all values.
  * @method static bool allDirectory($value, $message = null, $propertyPath = null) Assert that a directory exists for all values.
  * @method static bool allE164($value, $message = null, $propertyPath = null) Assert that the given string is a valid E164 Phone Number for all values.
@@ -103,6 +104,7 @@ use BadMethodCallException;
  * @method static bool nullOrContains($string, $needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string contains a sequence of chars or that the value is null.
  * @method static bool nullOrCount($countable, $count, $message = null, $propertyPath = null) Assert that the count of countable is equal to count or that the value is null.
  * @method static bool nullOrDate($value, $format, $message = null, $propertyPath = null) Assert that date is valid and corresponds to the given format or that the value is null.
+ * @method static bool nullOrDefined($constant, $message = null, $propertyPath = null) Assert that a constant is defined or that the value is null.
  * @method static bool nullOrDigit($value, $message = null, $propertyPath = null) Validates if an integer or integerish is a digit or that the value is null.
  * @method static bool nullOrDirectory($value, $message = null, $propertyPath = null) Assert that a directory exists or that the value is null.
  * @method static bool nullOrE164($value, $message = null, $propertyPath = null) Assert that the given string is a valid E164 Phone Number or that the value is null.
@@ -233,6 +235,7 @@ class Assertion
     const INVALID_IP                = 218;
     const INVALID_BETWEEN           = 219;
     const INVALID_BETWEEN_EXCLUSIVE = 220;
+    const INVALID_CONSTANT          = 221;
 
     /**
      * Exception to throw when an assertion failed.
@@ -2180,5 +2183,25 @@ class Assertion
         }
 
         return gettype($value);
+    }
+
+    /**
+     * Assert that a constant is defined.
+     *
+     * @param mixed $constant
+     * @param string|null $message
+     * @param string|null $propertyPath
+     * @return bool
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function defined($constant, $message = null, $propertyPath = null)
+    {
+        if (!defined($constant)) {
+            $message = sprintf($message ?: 'Value "%s" expected to be a defined constant.', $constant);
+
+            throw static::createException($constant, $message, static::INVALID_CONSTANT, $propertyPath);
+        }
+
+        return true;
     }
 }

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -33,6 +33,7 @@ use ReflectionClass;
  * @method AssertionChain contains($needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string contains a sequence of chars.
  * @method AssertionChain count($count, $message = null, $propertyPath = null) Assert that the count of countable is equal to count.
  * @method AssertionChain date($format, $message = null, $propertyPath = null) Assert that date is valid and corresponds to the given format.
+ * @method AssertionChain defined($message = null, $propertyPath = null) Assert that a constant is defined.
  * @method AssertionChain digit($message = null, $propertyPath = null) Validates if an integer or integerish is a digit.
  * @method AssertionChain directory($message = null, $propertyPath = null) Assert that a directory exists.
  * @method AssertionChain e164($message = null, $propertyPath = null) Assert that the given string is a valid E164 Phone Number.

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -31,6 +31,7 @@ use LogicException;
  * @method LazyAssertion contains($needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string contains a sequence of chars.
  * @method LazyAssertion count($count, $message = null, $propertyPath = null) Assert that the count of countable is equal to count.
  * @method LazyAssertion date($format, $message = null, $propertyPath = null) Assert that date is valid and corresponds to the given format.
+ * @method LazyAssertion defined($message = null, $propertyPath = null) Assert that a constant is defined.
  * @method LazyAssertion digit($message = null, $propertyPath = null) Validates if an integer or integerish is a digit.
  * @method LazyAssertion directory($message = null, $propertyPath = null) Assert that a directory exists.
  * @method LazyAssertion e164($message = null, $propertyPath = null) Assert that the given string is a valid E164 Phone Number.

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1570,6 +1570,19 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(Assertion::float(fopen('php://stdin', 'rb')));
     }
+
+    public function testValidConstant()
+    {
+        $this->assertTrue(Assertion::defined('PHP_VERSION'));
+    }
+
+    /**
+     * @expectedException \Assert\InvalidArgumentException
+     */
+    public function testInvalidConstant()
+    {
+        Assertion::defined('NOT_A_CONSTANT');
+    }
 }
 
 class ChildStdClass extends \stdClass


### PR DESCRIPTION
as a simple example:
```
20:50 $ php -r "echo NOT_A_CONSTANT;"
PHP Notice:  Use of undefined constant NOT_A_CONSTANT - assumed 'NOT_A_CONSTANT' in Command line code on line 1
PHP Stack trace:
PHP   1. {main}() Command line code:0

Notice: Use of undefined constant NOT_A_CONSTANT - assumed 'NOT_A_CONSTANT' in Command line code on line 1

Call Stack:
    0.0001     218768   1. {main}() Command line code:0

NOT_A_CONSTANT
```

this assertion will allow us to ensure that a constant is defined before attempting to use it which can cause php to make an assumption, generate a notice, and do something unexpected.

what do you think?