### PR TITLE
Fix: Disable xdebug in before_install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.php-cs-fixer
 
+before_install:
+  - phpenv config-rm xdebug.ini || true
+
 install:
   - composer update
-
-before_script:
-  - phpenv config-rm xdebug.ini || true
 
 script:
   - if [[ $LINT = true ]]; then


### PR DESCRIPTION
This PR

* [x] speeds up installation of dependencies by disabling `xdebug` in the `before_install` step

💁‍♂️ This should speed up things, I believe! 

For reference, see https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle.

Also see https://travis-ci.org/beberlei/assert/jobs/182005392#L173:

```
$ composer update

You are running composer with xdebug enabled. This has a major impact on runtime performance. See https://getcomposer.org/xdebug
```