### PR TITLE
Fix: No need to disable PSR-0 fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -4,7 +4,6 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
 $rules = array(
-    'psr0' => false,
     '@PSR2' => true,
 );
 


### PR DESCRIPTION
This PR

* [x] removes a rule from `.php_cs`

💁‍♂️ The PSR-0 fixer is not enabled by default anymore, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1329.