### PR TITLE
add assertion to check if an extension is loaded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Assertion::e164($value);
 Assertion::email($value);
 Assertion::endsWith($string, $needle);
 Assertion::eq($value, $value2);
+Assertion::extensionLoaded($value);
 Assertion::false($value);
 Assertion::file($value);
 Assertion::float($value);

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -38,6 +38,7 @@ use BadMethodCallException;
  * @method static bool allEmail($value, $message = null, $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL) for all values.
  * @method static bool allEndsWith($string, $needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string ends with a sequence of chars for all values.
  * @method static bool allEq($value, $value2, $message = null, $propertyPath = null) Assert that two values are equal (using == ) for all values.
+ * @method static bool allExtensionLoaded($value, $message = null, $propertyPath = null) Assert that extension is loaded for all values.
  * @method static bool allFalse($value, $message = null, $propertyPath = null) Assert that the value is boolean False for all values.
  * @method static bool allFile($value, $message = null, $propertyPath = null) Assert that a file exists for all values.
  * @method static bool allFloat($value, $message = null, $propertyPath = null) Assert that value is a php float for all values.
@@ -110,6 +111,7 @@ use BadMethodCallException;
  * @method static bool nullOrEmail($value, $message = null, $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL) or that the value is null.
  * @method static bool nullOrEndsWith($string, $needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string ends with a sequence of chars or that the value is null.
  * @method static bool nullOrEq($value, $value2, $message = null, $propertyPath = null) Assert that two values are equal (using == ) or that the value is null.
+ * @method static bool nullOrExtensionLoaded($value, $message = null, $propertyPath = null) Assert that extension is loaded or that the value is null.
  * @method static bool nullOrFalse($value, $message = null, $propertyPath = null) Assert that the value is boolean False or that the value is null.
  * @method static bool nullOrFile($value, $message = null, $propertyPath = null) Assert that a file exists or that the value is null.
  * @method static bool nullOrFloat($value, $message = null, $propertyPath = null) Assert that value is a php float or that the value is null.
@@ -234,6 +236,7 @@ class Assertion
     const INVALID_IP                = 218;
     const INVALID_BETWEEN           = 219;
     const INVALID_BETWEEN_EXCLUSIVE = 220;
+    const INVALID_EXTENSION         = 222;
 
     /**
      * Exception to throw when an assertion failed.
@@ -1992,6 +1995,29 @@ class Assertion
             );
 
             throw static::createException($value, $message, static::INVALID_BETWEEN_EXCLUSIVE, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert that extension is loaded.
+     *
+     * @param mixed $value
+     * @param string|null $message
+     * @param string|null $propertyPath
+     * @return bool
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function extensionLoaded($value, $message = null, $propertyPath = null)
+    {
+        if (! extension_loaded($value)) {
+            $message = sprintf(
+                $message ?: 'Extension "%s" is required.',
+                static::stringify($value)
+            );
+
+            throw static::createException($value, $message, static::INVALID_EXTENSION, $propertyPath);
         }
 
         return true;

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -39,6 +39,7 @@ use ReflectionClass;
  * @method AssertionChain email($message = null, $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL).
  * @method AssertionChain endsWith($needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string ends with a sequence of chars.
  * @method AssertionChain eq($value2, $message = null, $propertyPath = null) Assert that two values are equal (using == ).
+ * @method AssertionChain extensionLoaded($message = null, $propertyPath = null) Assert that extension is loaded.
  * @method AssertionChain false($message = null, $propertyPath = null) Assert that the value is boolean False.
  * @method AssertionChain file($message = null, $propertyPath = null) Assert that a file exists.
  * @method AssertionChain float($message = null, $propertyPath = null) Assert that value is a php float.

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -38,6 +38,7 @@ use LogicException;
  * @method LazyAssertion email($message = null, $propertyPath = null) Assert that value is an email adress (using input_filter/FILTER_VALIDATE_EMAIL).
  * @method LazyAssertion endsWith($needle, $message = null, $propertyPath = null, $encoding = "utf8") Assert that string ends with a sequence of chars.
  * @method LazyAssertion eq($value2, $message = null, $propertyPath = null) Assert that two values are equal (using == ).
+ * @method LazyAssertion extensionLoaded($message = null, $propertyPath = null) Assert that extension is loaded.
  * @method LazyAssertion false($message = null, $propertyPath = null) Assert that the value is boolean False.
  * @method LazyAssertion file($message = null, $propertyPath = null) Assert that a file exists.
  * @method LazyAssertion float($message = null, $propertyPath = null) Assert that value is a php float.

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1583,6 +1583,19 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(Assertion::float(fopen('php://stdin', 'rb')));
     }
+
+    public function testExtensionLoaded()
+    {
+        $this->assertTrue(Assertion::extensionLoaded('date'));
+    }
+
+    /**
+     * @expectedException \Assert\InvalidArgumentException
+     */
+    public function testExtensionNotLoaded()
+    {
+        Assertion::extensionLoaded('NOT_LOADED');
+    }
 }
 
 class ChildStdClass extends \stdClass


### PR DESCRIPTION
i could use such an assertion in factory code to generate a helpful message about which extension to install rather than letting PHP fail with a missing class error:

```
22:18 $ /usr/local/Cellar/php71/7.1.0_11/bin/php -r "new \Memcached;"
PHP Fatal error:  Uncaught Error: Class 'Memcached' not found in Command line code:1
Stack trace:
#0 {main}
  thrown in Command line code on line 1

Fatal error: Uncaught Error: Class 'Memcached' not found in Command line code on line 1

Error: Class 'Memcached' not found in Command line code on line 1

Call Stack:
    0.0001     346408   1. {main}() Command line code:0
```