### PR TITLE
add assertion to compare arbitrary versions and to compare PHP versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Assertion::notNull(mixed $value);
 Assertion::notSame(mixed $value1, mixed $value2);
 Assertion::null(mixed $value);
 Assertion::numeric(mixed $value);
+Assertion::phpVersion(string $operator, mixed $version);
 Assertion::range(mixed $value, mixed $minValue, mixed $maxValue);
 Assertion::readable(string $value);
 Assertion::regex(mixed $value, string $pattern);
@@ -240,6 +241,7 @@ Assertion::subclassOf(mixed $value, string $className);
 Assertion::true(mixed $value);
 Assertion::url(mixed $value);
 Assertion::uuid(string $value);
+Assertion::version(string $version1, string $operator, string $version2);
 Assertion::writeable(string $value);
 
 ```

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -82,6 +82,7 @@ use BadMethodCallException;
  * @method static bool allNotSame(mixed $value1, mixed $value2, string $message = null, string $propertyPath = null) Assert that two values are not the same (using === ) for all values.
  * @method static bool allNull(mixed $value, string $message = null, string $propertyPath = null) Assert that value is null for all values.
  * @method static bool allNumeric(mixed $value, string $message = null, string $propertyPath = null) Assert that value is numeric for all values.
+ * @method static bool allPhpVersion(string $operator, mixed $version, string $message = null, string $propertyPath = null) Assert that extension is loaded for all values.
  * @method static bool allRange(mixed $value, mixed $minValue, mixed $maxValue, string $message = null, string $propertyPath = null) Assert that value is in range of numbers for all values.
  * @method static bool allReadable(string $value, string $message = null, string $propertyPath = null) Assert that the value is something readable for all values.
  * @method static bool allRegex(mixed $value, string $pattern, string $message = null, string $propertyPath = null) Assert that value matches a regex for all values.
@@ -94,6 +95,7 @@ use BadMethodCallException;
  * @method static bool allTrue(mixed $value, string $message = null, string $propertyPath = null) Assert that the value is boolean True for all values.
  * @method static bool allUrl(mixed $value, string $message = null, string $propertyPath = null) Assert that value is an URL for all values.
  * @method static bool allUuid(string $value, string $message = null, string $propertyPath = null) Assert that the given string is a valid UUID for all values.
+ * @method static bool allVersion(string $version1, string $operator, string $version2, string $message = null, string $propertyPath = null) Assert that extension is loaded for all values.
  * @method static bool allWriteable(string $value, string $message = null, string $propertyPath = null) Assert that the value is something writeable for all values.
  * @method static bool nullOrAlnum(mixed $value, string $message = null, string $propertyPath = null) Assert that value is alphanumeric or that the value is null.
  * @method static bool nullOrBetween(mixed $value, mixed $lowerLimit, mixed $upperLimit, string $message = null, string $propertyPath = null) Assert that a value is greater or equal than a lower limit, and less than or equal to an upper limit or that the value is null.
@@ -156,6 +158,7 @@ use BadMethodCallException;
  * @method static bool nullOrNotSame(mixed $value1, mixed $value2, string $message = null, string $propertyPath = null) Assert that two values are not the same (using === ) or that the value is null.
  * @method static bool nullOrNull(mixed $value, string $message = null, string $propertyPath = null) Assert that value is null or that the value is null.
  * @method static bool nullOrNumeric(mixed $value, string $message = null, string $propertyPath = null) Assert that value is numeric or that the value is null.
+ * @method static bool nullOrPhpVersion(string $operator, mixed $version, string $message = null, string $propertyPath = null) Assert that extension is loaded or that the value is null.
  * @method static bool nullOrRange(mixed $value, mixed $minValue, mixed $maxValue, string $message = null, string $propertyPath = null) Assert that value is in range of numbers or that the value is null.
  * @method static bool nullOrReadable(string $value, string $message = null, string $propertyPath = null) Assert that the value is something readable or that the value is null.
  * @method static bool nullOrRegex(mixed $value, string $pattern, string $message = null, string $propertyPath = null) Assert that value matches a regex or that the value is null.
@@ -168,6 +171,7 @@ use BadMethodCallException;
  * @method static bool nullOrTrue(mixed $value, string $message = null, string $propertyPath = null) Assert that the value is boolean True or that the value is null.
  * @method static bool nullOrUrl(mixed $value, string $message = null, string $propertyPath = null) Assert that value is an URL or that the value is null.
  * @method static bool nullOrUuid(string $value, string $message = null, string $propertyPath = null) Assert that the given string is a valid UUID or that the value is null.
+ * @method static bool nullOrVersion(string $version1, string $operator, string $version2, string $message = null, string $propertyPath = null) Assert that extension is loaded or that the value is null.
  * @method static bool nullOrWriteable(string $value, string $message = null, string $propertyPath = null) Assert that the value is something writeable or that the value is null.
  */
 class Assertion
@@ -240,6 +244,7 @@ class Assertion
     const INVALID_BETWEEN_EXCLUSIVE = 220;
     const INVALID_EXTENSION         = 222;
     const INVALID_CONSTANT          = 221;
+    const INVALID_VERSION           = 223;
 
     /**
      * Exception to throw when an assertion failed.
@@ -2024,6 +2029,52 @@ class Assertion
         }
 
         return true;
+    }
+
+    /**
+     * Assert comparison of two versions.
+     *
+     * @param string $version1
+     * @param string $operator
+     * @param string $version2
+     * @param string|null $message
+     * @param string|null $propertyPath
+     * @return bool
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function version($version1, $operator, $version2, $message = null, $propertyPath = null)
+    {
+        static::notEmpty($operator, 'versionCompare operator is required and cannot be empty.');
+
+        if (version_compare($version1, $version2, $operator) !== true) {
+            $message = sprintf(
+                $message ?: 'Version "%s" is not "%s" version "%s".',
+                static::stringify($version1),
+                static::stringify($operator),
+                static::stringify($version2)
+            );
+
+            throw static::createException($version1, $message, static::INVALID_VERSION, $propertyPath);
+        }
+
+        return true;
+    }
+
+    /**
+     * Assert on PHP version.
+     *
+     * @param string $operator
+     * @param mixed $version
+     * @param string|null $message
+     * @param string|null $propertyPath
+     * @return bool
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function phpVersion($operator, $version, $message = null, $propertyPath = null)
+    {
+        static::defined('PHP_VERSION');
+
+        return static::version(PHP_VERSION, $operator, $version, $message, $propertyPath);
     }
 
     /**

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -83,6 +83,7 @@ use ReflectionClass;
  * @method AssertionChain notSame(mixed $value2, string $message = null, string $propertyPath = null) Assert that two values are not the same (using === ).
  * @method AssertionChain null(string $message = null, string $propertyPath = null) Assert that value is null.
  * @method AssertionChain numeric(string $message = null, string $propertyPath = null) Assert that value is numeric.
+ * @method AssertionChain phpVersion(mixed $version, string $message = null, string $propertyPath = null) Assert that extension is loaded.
  * @method AssertionChain range(mixed $minValue, mixed $maxValue, string $message = null, string $propertyPath = null) Assert that value is in range of numbers.
  * @method AssertionChain readable(string $message = null, string $propertyPath = null) Assert that the value is something readable.
  * @method AssertionChain regex(string $pattern, string $message = null, string $propertyPath = null) Assert that value matches a regex.
@@ -95,6 +96,7 @@ use ReflectionClass;
  * @method AssertionChain true(string $message = null, string $propertyPath = null) Assert that the value is boolean True.
  * @method AssertionChain url(string $message = null, string $propertyPath = null) Assert that value is an URL.
  * @method AssertionChain uuid(string $message = null, string $propertyPath = null) Assert that the given string is a valid UUID.
+ * @method AssertionChain version(string $operator, string $version2, string $message = null, string $propertyPath = null) Assert that extension is loaded.
  * @method AssertionChain writeable(string $message = null, string $propertyPath = null) Assert that the value is something writeable.
  */
 class AssertionChain

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -82,6 +82,7 @@ use LogicException;
  * @method LazyAssertion notSame(mixed $value2, string $message = null, string $propertyPath = null) Assert that two values are not the same (using === ).
  * @method LazyAssertion null(string $message = null, string $propertyPath = null) Assert that value is null.
  * @method LazyAssertion numeric(string $message = null, string $propertyPath = null) Assert that value is numeric.
+ * @method LazyAssertion phpVersion(mixed $version, string $message = null, string $propertyPath = null) Assert that extension is loaded.
  * @method LazyAssertion range(mixed $minValue, mixed $maxValue, string $message = null, string $propertyPath = null) Assert that value is in range of numbers.
  * @method LazyAssertion readable(string $message = null, string $propertyPath = null) Assert that the value is something readable.
  * @method LazyAssertion regex(string $pattern, string $message = null, string $propertyPath = null) Assert that value matches a regex.
@@ -94,6 +95,7 @@ use LogicException;
  * @method LazyAssertion true(string $message = null, string $propertyPath = null) Assert that the value is boolean True.
  * @method LazyAssertion url(string $message = null, string $propertyPath = null) Assert that value is an URL.
  * @method LazyAssertion uuid(string $message = null, string $propertyPath = null) Assert that the given string is a valid UUID.
+ * @method LazyAssertion version(string $operator, string $version2, string $message = null, string $propertyPath = null) Assert that extension is loaded.
  * @method LazyAssertion writeable(string $message = null, string $propertyPath = null) Assert that the value is something writeable.
  * @method LazyAssertion all() Switch chain into validation mode for an array of values.
  * @method LazyAssertion nullOr() Switch chain into mode allowing nulls, ignoring further assertions.

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1609,6 +1609,32 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         Assertion::defined('NOT_A_CONSTANT');
     }
+
+    public function testValidVersion()
+    {
+        $this->assertTrue(Assertion::version('1.0.0', '<', '2.0.0'));
+    }
+
+    /**
+     * @expectedException \Assert\InvalidArgumentException
+     */
+    public function testInvalidVersion()
+    {
+        Assertion::version('1.0.0', 'eq', '2.0.0');
+    }
+
+    /**
+     * @expectedException \Assert\InvalidArgumentException
+     */
+    public function testInvalidVersionOperator()
+    {
+        Assertion::version('1.0.0', null, '2.0.0');
+    }
+
+    public function testValidPhpVersion()
+    {
+        $this->assertTrue(Assertion::phpVersion('>', '4.0.0'));
+    }
 }
 
 class ChildStdClass extends \stdClass


### PR DESCRIPTION
this request adds assertions to compare versions, and a helper for PHP version specifically. i'm working on another request to assert extension versions, but am running into HHVM issues so that helper will have to wait.

of particular interest is my opinionated requirement of the `$operator` param. PHP's `version_compare` method does not require it, which changes the output/behavior of the method. i am not a fan of ambiguity so internally my new assertion asserts that `$operator` is not empty. i am open to suggestions. maybe my opinion is not so great : )