### PR TITLE
changed the parameter type hint from mixed to string

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -778,7 +778,7 @@ class Assertion
     /**
      * Assert that string value is not longer than $maxLength chars.
      *
-     * @param mixed                $value
+     * @param string               $value
      * @param int                  $maxLength
      * @param string|callable|null $message
      * @param string|null          $propertyPath


### PR DESCRIPTION
if the function asserts the max length of a string, the parameter type hint should be string instead of mixed.