### PR TITLE
Enhancement: Enable native_function_invocation fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -19,6 +19,7 @@ $rules = array(
     '@PSR2' => true,
     '@Symfony' => true,
     'concat_space' => false,
+    'native_function_invocation' => true,
     'psr4' => true,
     'phpdoc_align' => true,
     'header_comment' => array(

--- a/bin/generate_method_docs.php
+++ b/bin/generate_method_docs.php
@@ -36,57 +36,57 @@ class MethodDocGenerator
     private function generateMethodDocs(array $methods, $format, $skipParameterTest, $prefix = '')
     {
         $lines = array();
-        asort($methods);
+        \asort($methods);
         foreach ($methods as $method) {
             $doc = $method->getDocComment();
-            list(, $descriptionLine) = explode("\n", $doc);
-            $shortDescription = trim(substr($descriptionLine, 7), '.');
-            $methodName = $prefix.($prefix ? ucfirst($method->getName()) : $method->getName());
+            list(, $descriptionLine) = \explode("\n", $doc);
+            $shortDescription = \trim(\substr($descriptionLine, 7), '.');
+            $methodName = $prefix.($prefix ? \ucfirst($method->getName()) : $method->getName());
 
-            if (preg_match('`\* @aliasOf (?P<aliasOf>[^\s]++)`sim', $doc, $aliasMatch)) {
-                $shortDescription .= sprintf('. This is an alias of Assertion::%s()', trim($aliasMatch['aliasOf'], '(){}'));
+            if (\preg_match('`\* @aliasOf (?P<aliasOf>[^\s]++)`sim', $doc, $aliasMatch)) {
+                $shortDescription .= \sprintf('. This is an alias of Assertion::%s()', \trim($aliasMatch['aliasOf'], '(){}'));
             }
 
             $parameters = array();
 
             foreach ($method->getParameters() as $methodParameter) {
                 if (
-                    (is_bool($skipParameterTest) && $skipParameterTest) ||
-                    (is_callable($skipParameterTest) && $skipParameterTest($methodParameter))
+                    (\is_bool($skipParameterTest) && $skipParameterTest) ||
+                    (\is_callable($skipParameterTest) && $skipParameterTest($methodParameter))
                 ) {
                     continue;
                 }
 
                 $parameter = '$'.$methodParameter->getName();
 
-                $type = version_compare(PHP_VERSION, '7.0.0') >= 0 ? $methodParameter->getType() : null;
+                $type = \version_compare(PHP_VERSION, '7.0.0') >= 0 ? $methodParameter->getType() : null;
 
-                if (is_null($type)) {
-                    preg_match(sprintf('`\* @param (?P<type>[^ ]++) +\%s`sim', $parameter), $doc, $matches);
+                if (\is_null($type)) {
+                    \preg_match(\sprintf('`\* @param (?P<type>[^ ]++) +\%s`sim', $parameter), $doc, $matches);
                     if (isset($matches['type'])) {
                         $type = (
                             $methodParameter->isOptional() &&
                             null == $methodParameter->getDefaultValue()
                         )
-                            ? str_replace(['|null', 'null|'], '', $matches['type'])
+                            ? \str_replace(['|null', 'null|'], '', $matches['type'])
                             : $matches['type'];
                     }
                 }
-                \Assert\Assertion::notEmpty($type, sprintf('No type defined for %s in %s', $parameter, $methodName));
-                $parameter = sprintf('%s %s', $type, $parameter);
+                \Assert\Assertion::notEmpty($type, \sprintf('No type defined for %s in %s', $parameter, $methodName));
+                $parameter = \sprintf('%s %s', $type, $parameter);
 
                 if ($methodParameter->isOptional()) {
                     if (null === $methodParameter->getDefaultValue()) {
                         $parameter .= ' = null';
                     } else {
-                        $parameter .= sprintf(' = \'%s\'', $methodParameter->getDefaultValue());
+                        $parameter .= \sprintf(' = \'%s\'', $methodParameter->getDefaultValue());
                     }
                 }
 
                 $parameters[] = $parameter;
             }
 
-            $lines[] = sprintf($format, $methodName, implode(', ', $parameters), $shortDescription);
+            $lines[] = \sprintf($format, $methodName, \implode(', ', $parameters), $shortDescription);
         }
 
         return $lines;
@@ -99,14 +99,14 @@ class MethodDocGenerator
     {
         $reflClass = new ReflectionClass('Assert\Assertion');
 
-        return array_filter(
+        return \array_filter(
             $reflClass->getMethods(ReflectionMethod::IS_STATIC),
             function (ReflectionMethod $reflMethod) {
                 if ($reflMethod->isProtected()) {
                     return false;
                 }
 
-                if (in_array($reflMethod->getName(), array('__callStatic', 'createException', 'stringify'))) {
+                if (\in_array($reflMethod->getName(), array('__callStatic', 'createException', 'stringify'))) {
                     return false;
                 }
 
@@ -122,27 +122,27 @@ class MethodDocGenerator
      */
     private function generateFile($phpFile, $lines, $fileType)
     {
-        $phpFile = realpath($phpFile);
-        $fileContent = file_get_contents($phpFile);
+        $phpFile = \realpath($phpFile);
+        $fileContent = \file_get_contents($phpFile);
 
         switch ($fileType) {
             case 'class':
-                $fileContent = preg_replace(
+                $fileContent = \preg_replace(
                     '`\* @method.*? \*/\nclass `sim',
-                    sprintf("%s\n */\nclass ", trim(implode("\n", $lines))),
+                    \sprintf("%s\n */\nclass ", \trim(\implode("\n", $lines))),
                     $fileContent
                 );
                 break;
             case 'readme':
-                $fileContent = preg_replace(
+                $fileContent = \preg_replace(
                     '/```php\n<\?php\nuse Assert\\\Assertion;\n\nAssertion::.*?```/sim',
-                    sprintf("```php\n<?php\nuse Assert\\Assertion;\n\n%s\n\n```", implode("\n", $lines)),
+                    \sprintf("```php\n<?php\nuse Assert\\Assertion;\n\n%s\n\n```", \implode("\n", $lines)),
                     $fileContent
                 );
                 break;
         }
 
-        $writtenBytes = file_put_contents($phpFile, $fileContent);
+        $writtenBytes = \file_put_contents($phpFile, $fileContent);
 
         if ($writtenBytes !== false) {
             echo 'Generated '.$phpFile.'.'.PHP_EOL;
@@ -156,7 +156,7 @@ class MethodDocGenerator
             return false;
         };
 
-        $docs = array_merge(
+        $docs = \array_merge(
             $this->generateMethodDocs($this->gatherAssertions(), ' * @method static bool %s(%s) %s for all values.', $skipParameterTest, 'all'),
             $this->generateMethodDocs($this->gatherAssertions(), ' * @method static bool %s(%s) %s or that the value is null.', $skipParameterTest, 'nullOr')
         );
@@ -168,7 +168,7 @@ class MethodDocGenerator
     {
         $mdFile = __DIR__.'/../README.md';
         $skipParameterTest = function (ReflectionParameter $parameter) {
-            return in_array($parameter->getName(), array('message', 'propertyPath', 'encoding'));
+            return \in_array($parameter->getName(), array('message', 'propertyPath', 'encoding'));
         };
 
         $docs = $this->generateMethodDocs($this->gatherAssertions(), 'Assertion::%s(%s);', $skipParameterTest);
@@ -183,7 +183,7 @@ class MethodDocGenerator
             return $parameter->getPosition() === 0;
         };
 
-        $docs = array_merge(
+        $docs = \array_merge(
             $this->generateMethodDocs($this->gatherAssertions(), ' * @method LazyAssertion %s(%s) %s.', $skipParameterTest),
             $this->generateMethodDocs($this->gatherAssertionChainSwitches(), ' * @method LazyAssertion %s(%s) %s.', false)
         );
@@ -198,14 +198,14 @@ class MethodDocGenerator
     {
         $reflClass = new ReflectionClass('Assert\AssertionChain');
 
-        return array_filter(
+        return \array_filter(
             $reflClass->getMethods(ReflectionMethod::IS_PUBLIC),
             function (ReflectionMethod $reflMethod) {
                 if (!$reflMethod->isPublic()) {
                     return false;
                 }
 
-                if (in_array($reflMethod->getName(), array('__construct', '__call', 'setAssertionClassName'))) {
+                if (\in_array($reflMethod->getName(), array('__construct', '__call', 'setAssertionClassName'))) {
                     return false;
                 }
 

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -290,7 +290,7 @@ class Assertion
     public static function eq($value, $value2, $message = null, $propertyPath = null)
     {
         if ($value != $value2) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" does not equal expected value "%s".',
                 static::stringify($value),
                 static::stringify($value2)
@@ -317,7 +317,7 @@ class Assertion
     public static function same($value, $value2, $message = null, $propertyPath = null)
     {
         if ($value !== $value2) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not the same as expected value "%s".',
                 static::stringify($value),
                 static::stringify($value2)
@@ -344,7 +344,7 @@ class Assertion
     public static function notEq($value1, $value2, $message = null, $propertyPath = null)
     {
         if ($value1 == $value2) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is equal to expected value "%s".',
                 static::stringify($value1),
                 static::stringify($value2)
@@ -370,7 +370,7 @@ class Assertion
     public static function notSame($value1, $value2, $message = null, $propertyPath = null)
     {
         if ($value1 === $value2) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is the same as expected value "%s".',
                 static::stringify($value1),
                 static::stringify($value2)
@@ -395,8 +395,8 @@ class Assertion
      */
     public static function notInArray($value, array $choices, $message = null, $propertyPath = null)
     {
-        if (in_array($value, $choices) === true) {
-            $message = sprintf(
+        if (\in_array($value, $choices) === true) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is in given "%s".',
                 static::stringify($value),
                 static::stringify($choices)
@@ -420,8 +420,8 @@ class Assertion
      */
     public static function integer($value, $message = null, $propertyPath = null)
     {
-        if (!is_int($value)) {
-            $message = sprintf(
+        if (!\is_int($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not an integer.',
                 static::stringify($value)
             );
@@ -445,8 +445,8 @@ class Assertion
      */
     public static function float($value, $message = null, $propertyPath = null)
     {
-        if (!is_float($value)) {
-            $message = sprintf(
+        if (!\is_float($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a float.',
                 static::stringify($value)
             );
@@ -470,8 +470,8 @@ class Assertion
      */
     public static function digit($value, $message = null, $propertyPath = null)
     {
-        if (!ctype_digit((string) $value)) {
-            $message = sprintf(
+        if (!\ctype_digit((string) $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a digit.',
                 static::stringify($value)
             );
@@ -495,8 +495,8 @@ class Assertion
      */
     public static function integerish($value, $message = null, $propertyPath = null)
     {
-        if (is_resource($value) || is_object($value) || strval(intval($value)) != $value || is_bool($value) || is_null($value)) {
-            $message = sprintf(
+        if (\is_resource($value) || \is_object($value) || \strval(\intval($value)) != $value || \is_bool($value) || \is_null($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not an integer or a number castable to integer.',
                 static::stringify($value)
             );
@@ -520,8 +520,8 @@ class Assertion
      */
     public static function boolean($value, $message = null, $propertyPath = null)
     {
-        if (!is_bool($value)) {
-            $message = sprintf(
+        if (!\is_bool($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a boolean.',
                 static::stringify($value)
             );
@@ -545,8 +545,8 @@ class Assertion
      */
     public static function scalar($value, $message = null, $propertyPath = null)
     {
-        if (!is_scalar($value)) {
-            $message = sprintf(
+        if (!\is_scalar($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a scalar.',
                 static::stringify($value)
             );
@@ -571,7 +571,7 @@ class Assertion
     public static function notEmpty($value, $message = null, $propertyPath = null)
     {
         if (empty($value)) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is empty, but non empty value was expected.',
                 static::stringify($value)
             );
@@ -596,7 +596,7 @@ class Assertion
     public static function noContent($value, $message = null, $propertyPath = null)
     {
         if (!empty($value)) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not empty, but empty value was expected.',
                 static::stringify($value)
             );
@@ -621,7 +621,7 @@ class Assertion
     public static function null($value, $message = null, $propertyPath = null)
     {
         if ($value !== null) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not null, but null value was expected.',
                 static::stringify($value)
             );
@@ -646,7 +646,7 @@ class Assertion
     public static function notNull($value, $message = null, $propertyPath = null)
     {
         if ($value === null) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is null, but non null value was expected.',
                 static::stringify($value)
             );
@@ -670,11 +670,11 @@ class Assertion
      */
     public static function string($value, $message = null, $propertyPath = null)
     {
-        if (!is_string($value)) {
-            $message = sprintf(
+        if (!\is_string($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" expected to be string, type %s given.',
                 static::stringify($value),
-                gettype($value)
+                \gettype($value)
             );
 
             throw static::createException($value, $message, static::INVALID_STRING, $propertyPath);
@@ -699,8 +699,8 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (!preg_match($pattern, $value)) {
-            $message = sprintf(
+        if (!\preg_match($pattern, $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" does not match expression.',
                 static::stringify($value)
             );
@@ -728,12 +728,12 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (mb_strlen($value, $encoding) !== $length) {
-            $message = sprintf(
+        if (\mb_strlen($value, $encoding) !== $length) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" has to be %d exactly characters long, but length is %d.',
                 static::stringify($value),
                 $length,
-                mb_strlen($value, $encoding)
+                \mb_strlen($value, $encoding)
             );
 
             $constraints = array('length' => $length, 'encoding' => $encoding);
@@ -760,12 +760,12 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (mb_strlen($value, $encoding) < $minLength) {
-            $message = sprintf(
+        if (\mb_strlen($value, $encoding) < $minLength) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is too short, it should have at least %d characters, but only has %d characters.',
                 static::stringify($value),
                 $minLength,
-                mb_strlen($value, $encoding)
+                \mb_strlen($value, $encoding)
             );
 
             $constraints = array('min_length' => $minLength, 'encoding' => $encoding);
@@ -792,12 +792,12 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (mb_strlen($value, $encoding) > $maxLength) {
-            $message = sprintf(
+        if (\mb_strlen($value, $encoding) > $maxLength) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is too long, it should have no more than %d characters, but has %d characters.',
                 static::stringify($value),
                 $maxLength,
-                mb_strlen($value, $encoding)
+                \mb_strlen($value, $encoding)
             );
 
             $constraints = array('max_length' => $maxLength, 'encoding' => $encoding);
@@ -847,8 +847,8 @@ class Assertion
     {
         static::string($string, $message, $propertyPath);
 
-        if (mb_strpos($string, $needle, null, $encoding) !== 0) {
-            $message = sprintf(
+        if (\mb_strpos($string, $needle, null, $encoding) !== 0) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" does not start with "%s".',
                 static::stringify($string),
                 static::stringify($needle)
@@ -878,10 +878,10 @@ class Assertion
     {
         static::string($string, $message, $propertyPath);
 
-        $stringPosition = mb_strlen($string, $encoding) - mb_strlen($needle, $encoding);
+        $stringPosition = \mb_strlen($string, $encoding) - \mb_strlen($needle, $encoding);
 
-        if (mb_strripos($string, $needle, null, $encoding) !== $stringPosition) {
-            $message = sprintf(
+        if (\mb_strripos($string, $needle, null, $encoding) !== $stringPosition) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" does not end with "%s".',
                 static::stringify($string),
                 static::stringify($needle)
@@ -911,8 +911,8 @@ class Assertion
     {
         static::string($string, $message, $propertyPath);
 
-        if (mb_strpos($string, $needle, null, $encoding) === false) {
-            $message = sprintf(
+        if (\mb_strpos($string, $needle, null, $encoding) === false) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" does not contain "%s".',
                 static::stringify($string),
                 static::stringify($needle)
@@ -939,11 +939,11 @@ class Assertion
      */
     public static function choice($value, array $choices, $message = null, $propertyPath = null)
     {
-        if (!in_array($value, $choices, true)) {
-            $message = sprintf(
+        if (!\in_array($value, $choices, true)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not an element of the valid values: %s',
                 static::stringify($value),
-                implode(', ', array_map(array(get_called_class(), 'stringify'), $choices))
+                \implode(', ', \array_map(array(\get_called_class(), 'stringify'), $choices))
             );
 
             throw static::createException($value, $message, static::INVALID_CHOICE, $propertyPath, array('choices' => $choices));
@@ -984,8 +984,8 @@ class Assertion
      */
     public static function numeric($value, $message = null, $propertyPath = null)
     {
-        if (!is_numeric($value)) {
-            $message = sprintf(
+        if (!\is_numeric($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not numeric.',
                 static::stringify($value)
             );
@@ -1009,8 +1009,8 @@ class Assertion
      */
     public static function isArray($value, $message = null, $propertyPath = null)
     {
-        if (!is_array($value)) {
-            $message = sprintf(
+        if (!\is_array($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not an array.',
                 static::stringify($value)
             );
@@ -1034,8 +1034,8 @@ class Assertion
      */
     public static function isTraversable($value, $message = null, $propertyPath = null)
     {
-        if (!is_array($value) && !$value instanceof \Traversable) {
-            $message = sprintf(
+        if (!\is_array($value) && !$value instanceof \Traversable) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not an array and does not implement Traversable.',
                 static::stringify($value)
             );
@@ -1059,8 +1059,8 @@ class Assertion
      */
     public static function isArrayAccessible($value, $message = null, $propertyPath = null)
     {
-        if (!is_array($value) && !$value instanceof \ArrayAccess) {
-            $message = sprintf(
+        if (!\is_array($value) && !$value instanceof \ArrayAccess) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not an array and does not implement ArrayAccess.',
                 static::stringify($value)
             );
@@ -1087,8 +1087,8 @@ class Assertion
     {
         static::isArray($value, $message, $propertyPath);
 
-        if (!array_key_exists($key, $value)) {
-            $message = sprintf(
+        if (!\array_key_exists($key, $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Array does not contain an element with key "%s"',
                 static::stringify($key)
             );
@@ -1115,8 +1115,8 @@ class Assertion
     {
         static::isArray($value, $message, $propertyPath);
 
-        if (array_key_exists($key, $value)) {
-            $message = sprintf(
+        if (\array_key_exists($key, $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Array contains an element with key "%s"',
                 static::stringify($key)
             );
@@ -1144,7 +1144,7 @@ class Assertion
         static::isArrayAccessible($value, $message, $propertyPath);
 
         if (!isset($value[$key])) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'The element with key "%s" was not found',
                 static::stringify($key)
             );
@@ -1188,8 +1188,8 @@ class Assertion
      */
     public static function notBlank($value, $message = null, $propertyPath = null)
     {
-        if (false === $value || (empty($value) && '0' != $value) || (is_string($value) && '' === trim($value))) {
-            $message = sprintf(
+        if (false === $value || (empty($value) && '0' != $value) || (\is_string($value) && '' === \trim($value))) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is blank, but was expected to contain a value.',
                 static::stringify($value)
             );
@@ -1215,7 +1215,7 @@ class Assertion
     public static function isInstanceOf($value, $className, $message = null, $propertyPath = null)
     {
         if (!($value instanceof $className)) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Class "%s" was expected to be instanceof of "%s" but is not.',
                 static::stringify($value),
                 $className
@@ -1242,7 +1242,7 @@ class Assertion
     public static function notIsInstanceOf($value, $className, $message = null, $propertyPath = null)
     {
         if ($value instanceof $className) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Class "%s" was not expected to be instanceof of "%s".',
                 static::stringify($value),
                 $className
@@ -1268,8 +1268,8 @@ class Assertion
      */
     public static function subclassOf($value, $className, $message = null, $propertyPath = null)
     {
-        if (!is_subclass_of($value, $className)) {
-            $message = sprintf(
+        if (!\is_subclass_of($value, $className)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Class "%s" was expected to be subclass of "%s".',
                 static::stringify($value),
                 $className
@@ -1299,7 +1299,7 @@ class Assertion
         static::numeric($value, $message, $propertyPath);
 
         if ($value < $minValue || $value > $maxValue) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Number "%s" was expected to be at least "%d" and at most "%d".',
                 static::stringify($value),
                 static::stringify($minValue),
@@ -1329,7 +1329,7 @@ class Assertion
         static::numeric($value, $message, $propertyPath);
 
         if ($value < $minValue) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Number "%s" was expected to be at least "%s".',
                 static::stringify($value),
                 static::stringify($minValue)
@@ -1358,7 +1358,7 @@ class Assertion
         static::numeric($value, $message, $propertyPath);
 
         if ($value > $maxValue) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Number "%s" was expected to be at most "%s".',
                 static::stringify($value),
                 static::stringify($maxValue)
@@ -1386,8 +1386,8 @@ class Assertion
         static::string($value, $message, $propertyPath);
         static::notEmpty($value, $message, $propertyPath);
 
-        if (!is_file($value)) {
-            $message = sprintf(
+        if (!\is_file($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'File "%s" was expected to exist.',
                 static::stringify($value)
             );
@@ -1413,8 +1413,8 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (!is_dir($value)) {
-            $message = sprintf(
+        if (!\is_dir($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Path "%s" was expected to be a directory.',
                 static::stringify($value)
             );
@@ -1440,8 +1440,8 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (!is_readable($value)) {
-            $message = sprintf(
+        if (!\is_readable($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Path "%s" was expected to be readable.',
                 static::stringify($value)
             );
@@ -1467,8 +1467,8 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (!is_writable($value)) {
-            $message = sprintf(
+        if (!\is_writable($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Path "%s" was expected to be writeable.',
                 static::stringify($value)
             );
@@ -1494,19 +1494,19 @@ class Assertion
     {
         static::string($value, $message, $propertyPath);
 
-        if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
-            $message = sprintf(
+        if (!\filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" was expected to be a valid e-mail address.',
                 static::stringify($value)
             );
 
             throw static::createException($value, $message, static::INVALID_EMAIL, $propertyPath);
         } else {
-            $host = substr($value, strpos($value, '@') + 1);
+            $host = \substr($value, \strpos($value, '@') + 1);
 
             // Likely not a FQDN, bug in PHP FILTER_VALIDATE_EMAIL prior to PHP 5.3.3
-            if (version_compare(PHP_VERSION, '5.3.3', '<') && strpos($host, '.') === false) {
-                $message = sprintf(
+            if (\version_compare(PHP_VERSION, '5.3.3', '<') && \strpos($host, '.') === false) {
+                $message = \sprintf(
                     static::generateMessage($message) ?: 'Value "%s" was expected to be a valid e-mail address.',
                     static::stringify($value)
                 );
@@ -1556,10 +1556,10 @@ class Assertion
             (/?|/\S+|\?\S*|\#\S*)                   # a /, nothing, a / with something, a query or a fragment
         $~ixu';
 
-        $pattern = sprintf($pattern, implode('|', $protocols));
+        $pattern = \sprintf($pattern, \implode('|', $protocols));
 
-        if (!preg_match($pattern, $value)) {
-            $message = sprintf(
+        if (!\preg_match($pattern, $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" was expected to be a valid URL starting with http or https',
                 static::stringify($value)
             );
@@ -1586,7 +1586,7 @@ class Assertion
         try {
             static::regex($value, '(^([a-zA-Z]{1}[a-zA-Z0-9]*)$)', $message, $propertyPath);
         } catch (AssertionFailedException $e) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not alphanumeric, starting with letters and containing only letters and numbers.',
                 static::stringify($value)
             );
@@ -1611,7 +1611,7 @@ class Assertion
     public static function true($value, $message = null, $propertyPath = null)
     {
         if ($value !== true) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not TRUE.',
                 static::stringify($value)
             );
@@ -1636,7 +1636,7 @@ class Assertion
     public static function false($value, $message = null, $propertyPath = null)
     {
         if ($value !== false) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not FALSE.',
                 static::stringify($value)
             );
@@ -1660,8 +1660,8 @@ class Assertion
      */
     public static function classExists($value, $message = null, $propertyPath = null)
     {
-        if (!class_exists($value)) {
-            $message = sprintf(
+        if (!\class_exists($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Class "%s" does not exist.',
                 static::stringify($value)
             );
@@ -1685,8 +1685,8 @@ class Assertion
      */
     public static function interfaceExists($value, $message = null, $propertyPath = null)
     {
-        if (!interface_exists($value)) {
-            $message = sprintf(
+        if (!\interface_exists($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Interface "%s" does not exist.',
                 static::stringify($value)
             );
@@ -1713,7 +1713,7 @@ class Assertion
     {
         $reflection = new \ReflectionClass($class);
         if (!$reflection->implementsInterface($interfaceName)) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Class "%s" does not implement interface "%s".',
                 static::stringify($class),
                 static::stringify($interfaceName)
@@ -1744,8 +1744,8 @@ class Assertion
      */
     public static function isJsonString($value, $message = null, $propertyPath = null)
     {
-        if (null === json_decode($value) && JSON_ERROR_NONE !== json_last_error()) {
-            $message = sprintf(
+        if (null === \json_decode($value) && JSON_ERROR_NONE !== \json_last_error()) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a valid JSON string.',
                 static::stringify($value)
             );
@@ -1771,14 +1771,14 @@ class Assertion
      */
     public static function uuid($value, $message = null, $propertyPath = null)
     {
-        $value = str_replace(array('urn:', 'uuid:', '{', '}'), '', $value);
+        $value = \str_replace(array('urn:', 'uuid:', '{', '}'), '', $value);
 
         if ($value === '00000000-0000-0000-0000-000000000000') {
             return true;
         }
 
-        if (!preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', $value)) {
-            $message = sprintf(
+        if (!\preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a valid UUID.',
                 static::stringify($value)
             );
@@ -1804,8 +1804,8 @@ class Assertion
      */
     public static function e164($value, $message = null, $propertyPath = null)
     {
-        if (!preg_match('/^\+?[1-9]\d{1,14}$/', $value)) {
-            $message = sprintf(
+        if (!\preg_match('/^\+?[1-9]\d{1,14}$/', $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" is not a valid E164.',
                 static::stringify($value)
             );
@@ -1830,8 +1830,8 @@ class Assertion
      */
     public static function count($countable, $count, $message = null, $propertyPath = null)
     {
-        if ($count !== count($countable)) {
-            $message = sprintf(
+        if ($count !== \count($countable)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'List does not contain exactly "%d" elements.',
                 static::stringify($count)
             );
@@ -1854,8 +1854,8 @@ class Assertion
      */
     public static function __callStatic($method, $args)
     {
-        if (strpos($method, 'nullOr') === 0) {
-            if (!array_key_exists(0, $args)) {
+        if (\strpos($method, 'nullOr') === 0) {
+            if (!\array_key_exists(0, $args)) {
                 throw new BadMethodCallException('Missing the first argument.');
             }
 
@@ -1863,24 +1863,24 @@ class Assertion
                 return true;
             }
 
-            $method = substr($method, 6);
+            $method = \substr($method, 6);
 
-            return call_user_func_array(array(get_called_class(), $method), $args);
+            return \call_user_func_array(array(\get_called_class(), $method), $args);
         }
 
-        if (strpos($method, 'all') === 0) {
-            if (!array_key_exists(0, $args)) {
+        if (\strpos($method, 'all') === 0) {
+            if (!\array_key_exists(0, $args)) {
                 throw new BadMethodCallException('Missing the first argument.');
             }
 
             static::isTraversable($args[0]);
 
-            $method = substr($method, 3);
-            $values = array_shift($args);
-            $calledClass = get_called_class();
+            $method = \substr($method, 3);
+            $values = \array_shift($args);
+            $calledClass = \get_called_class();
 
             foreach ($values as $value) {
-                call_user_func_array(array($calledClass, $method), array_merge(array($value), $args));
+                \call_user_func_array(array($calledClass, $method), \array_merge(array($value), $args));
             }
 
             return true;
@@ -1926,8 +1926,8 @@ class Assertion
     {
         static::isObject($object, $message, $propertyPath);
 
-        if (!method_exists($object, $value)) {
-            $message = sprintf(
+        if (!\method_exists($object, $value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Expected "%s" does not exist in provided object.',
                 static::stringify($value)
             );
@@ -1949,8 +1949,8 @@ class Assertion
      */
     public static function isObject($value, $message = null, $propertyPath = null)
     {
-        if (!is_object($value)) {
-            $message = sprintf(
+        if (!\is_object($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is not a valid object.',
                 static::stringify($value)
             );
@@ -1974,7 +1974,7 @@ class Assertion
     public static function lessThan($value, $limit, $message = null, $propertyPath = null)
     {
         if ($value >= $limit) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is not less than "%s".',
                 static::stringify($value),
                 static::stringify($limit)
@@ -1999,7 +1999,7 @@ class Assertion
     public static function lessOrEqualThan($value, $limit, $message = null, $propertyPath = null)
     {
         if ($value > $limit) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is not less or equal than "%s".',
                 static::stringify($value),
                 static::stringify($limit)
@@ -2024,7 +2024,7 @@ class Assertion
     public static function greaterThan($value, $limit, $message = null, $propertyPath = null)
     {
         if ($value <= $limit) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is not greater than "%s".',
                 static::stringify($value),
                 static::stringify($limit)
@@ -2049,7 +2049,7 @@ class Assertion
     public static function greaterOrEqualThan($value, $limit, $message = null, $propertyPath = null)
     {
         if ($value < $limit) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is not greater or equal than "%s".',
                 static::stringify($value),
                 static::stringify($limit)
@@ -2075,7 +2075,7 @@ class Assertion
     public static function between($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null)
     {
         if ($lowerLimit > $value || $value > $upperLimit) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is neither greater than or equal to "%s" nor less than or equal to "%s".',
                 static::stringify($value),
                 static::stringify($lowerLimit),
@@ -2102,7 +2102,7 @@ class Assertion
     public static function betweenExclusive($value, $lowerLimit, $upperLimit, $message = null, $propertyPath = null)
     {
         if ($lowerLimit >= $value || $value >= $upperLimit) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is neither greater than "%s" nor less than "%s".',
                 static::stringify($value),
                 static::stringify($lowerLimit),
@@ -2128,8 +2128,8 @@ class Assertion
      */
     public static function extensionLoaded($value, $message = null, $propertyPath = null)
     {
-        if (!extension_loaded($value)) {
-            $message = sprintf(
+        if (!\extension_loaded($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Extension "%s" is required.',
                 static::stringify($value)
             );
@@ -2161,7 +2161,7 @@ class Assertion
         $dateTime = \DateTime::createFromFormat($format, $value);
 
         if (false === $dateTime || $value !== $dateTime->format($format)) {
-            $message = sprintf(
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Date "%s" is invalid or does not match format "%s".',
                 static::stringify($value),
                 static::stringify($format)
@@ -2190,8 +2190,8 @@ class Assertion
     {
         static::notEmpty($operator, 'versionCompare operator is required and cannot be empty.');
 
-        if (version_compare($version1, $version2, $operator) !== true) {
-            $message = sprintf(
+        if (\version_compare($version1, $version2, $operator) !== true) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Version "%s" is not "%s" version "%s".',
                 static::stringify($version1),
                 static::stringify($operator),
@@ -2240,7 +2240,7 @@ class Assertion
     {
         static::extensionLoaded($extension, $message, $propertyPath);
 
-        return static::version(phpversion($extension), $operator, $version, $message, $propertyPath);
+        return static::version(\phpversion($extension), $operator, $version, $message, $propertyPath);
     }
 
     /**
@@ -2254,8 +2254,8 @@ class Assertion
      */
     public static function isCallable($value, $message = null, $propertyPath = null)
     {
-        if (!is_callable($value)) {
-            $message = sprintf(
+        if (!\is_callable($value)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is not a callable.',
                 static::stringify($value)
             );
@@ -2282,8 +2282,8 @@ class Assertion
     {
         static::isCallable($callback);
 
-        if (call_user_func($callback, $value) === false) {
-            $message = sprintf(
+        if (\call_user_func($callback, $value) === false) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Provided "%s" is invalid according to custom rule.',
                 static::stringify($value)
             );
@@ -2310,8 +2310,8 @@ class Assertion
     public static function ip($value, $flag = null, $message = null, $propertyPath = null)
     {
         static::string($value, $message, $propertyPath);
-        if (!filter_var($value, FILTER_VALIDATE_IP, $flag)) {
-            $message = sprintf(
+        if (!\filter_var($value, FILTER_VALIDATE_IP, $flag)) {
+            $message = \sprintf(
                 static::generateMessage($message) ?: 'Value "%s" was expected to be a valid IP address.',
                 static::stringify($value)
             );
@@ -2370,32 +2370,32 @@ class Assertion
      */
     protected static function stringify($value)
     {
-        $result = gettype($value);
+        $result = \gettype($value);
 
-        if (is_bool($value)) {
+        if (\is_bool($value)) {
             $result = $value ? '<TRUE>' : '<FALSE>';
         }
 
-        if (is_scalar($value)) {
+        if (\is_scalar($value)) {
             $val = (string) $value;
 
-            if (strlen($val) > 100) {
-                $val = substr($val, 0, 97) . '...';
+            if (\strlen($val) > 100) {
+                $val = \substr($val, 0, 97) . '...';
             }
 
             $result = $val;
         }
 
-        if (is_array($value)) {
+        if (\is_array($value)) {
             $result = '<ARRAY>';
         }
 
-        if (is_object($value)) {
-            $result = get_class($value);
+        if (\is_object($value)) {
+            $result = \get_class($value);
         }
 
-        if (is_resource($value)) {
-            $result = get_resource_type($value);
+        if (\is_resource($value)) {
+            $result = \get_resource_type($value);
         }
 
         if ($value === null) {
@@ -2418,8 +2418,8 @@ class Assertion
      */
     public static function defined($constant, $message = null, $propertyPath = null)
     {
-        if (!defined($constant)) {
-            $message = sprintf(static::generateMessage($message) ?: 'Value "%s" expected to be a defined constant.', $constant);
+        if (!\defined($constant)) {
+            $message = \sprintf(static::generateMessage($message) ?: 'Value "%s" expected to be a defined constant.', $constant);
 
             throw static::createException($constant, $message, static::INVALID_CONSTANT, $propertyPath);
         }
@@ -2436,8 +2436,8 @@ class Assertion
      */
     protected static function generateMessage($message = null)
     {
-        if (is_callable($message)) {
-            $traces = debug_backtrace(0);
+        if (\is_callable($message)) {
+            $traces = \debug_backtrace(0);
 
             $parameters = array();
 
@@ -2445,17 +2445,17 @@ class Assertion
             $method = $reflection->getMethod($traces[1]['function']);
             foreach ($method->getParameters() as $index => $parameter) {
                 if ($parameter->getName() !== 'message') {
-                    $parameters[$parameter->getName()] = array_key_exists($index, $traces[1]['args'])
+                    $parameters[$parameter->getName()] = \array_key_exists($index, $traces[1]['args'])
                         ? $traces[1]['args'][$index]
                         : $parameter->getDefaultValue();
                 }
             }
 
-            $parameters['::assertion'] = sprintf('%s%s%s', $traces[1]['class'], $traces[1]['type'], $traces[1]['function']);
+            $parameters['::assertion'] = \sprintf('%s%s%s', $traces[1]['class'], $traces[1]['type'], $traces[1]['function']);
 
-            $message = call_user_func_array($message, array($parameters));
+            $message = \call_user_func_array($message, array($parameters));
         }
 
-        return is_null($message) ? null : (string) $message;
+        return \is_null($message) ? null : (string) $message;
     }
 }

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -144,14 +144,14 @@ class AssertionChain
             return $this;
         }
 
-        if (!method_exists($this->assertionClassName, $methodName)) {
+        if (!\method_exists($this->assertionClassName, $methodName)) {
             throw new \RuntimeException("Assertion '" . $methodName . "' does not exist.");
         }
 
         $reflClass = new ReflectionClass($this->assertionClassName);
         $method = $reflClass->getMethod($methodName);
 
-        array_unshift($args, $this->value);
+        \array_unshift($args, $this->value);
         $params = $method->getParameters();
 
         foreach ($params as $idx => $param) {
@@ -172,7 +172,7 @@ class AssertionChain
             $methodName = 'all' . $methodName;
         }
 
-        call_user_func_array(array($this->assertionClassName, $methodName), $args);
+        \call_user_func_array(array($this->assertionClassName, $methodName), $args);
 
         return $this;
     }
@@ -210,11 +210,11 @@ class AssertionChain
      */
     public function setAssertionClassName($className)
     {
-        if (!is_string($className)) {
+        if (!\is_string($className)) {
             throw new LogicException('Exception class name must be passed as a string');
         }
 
-        if ($className !== 'Assert\Assertion' && !is_subclass_of($className, 'Assert\Assertion')) {
+        if ($className !== 'Assert\Assertion' && !\is_subclass_of($className, 'Assert\Assertion')) {
             throw new LogicException($className . ' is not (a subclass of) Assert\Assertion');
         }
 

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -142,7 +142,7 @@ class LazyAssertion
         }
 
         try {
-            call_user_func_array(array($this->currentChain, $method), $args);
+            \call_user_func_array(array($this->currentChain, $method), $args);
         } catch (AssertionFailedException $e) {
             $this->errors[] = $e;
             $this->currentChainFailed = true;
@@ -159,7 +159,7 @@ class LazyAssertion
     public function verifyNow()
     {
         if ($this->errors) {
-            throw call_user_func(array($this->exceptionClass, 'fromErrors'), $this->errors);
+            throw \call_user_func(array($this->exceptionClass, 'fromErrors'), $this->errors);
         }
 
         return true;
@@ -172,11 +172,11 @@ class LazyAssertion
      */
     public function setExceptionClass($className)
     {
-        if (!is_string($className)) {
+        if (!\is_string($className)) {
             throw new LogicException('Exception class name must be passed as a string');
         }
 
-        if ($className !== 'Assert\LazyAssertionException' && !is_subclass_of($className, 'Assert\LazyAssertionException')) {
+        if ($className !== 'Assert\LazyAssertionException' && !\is_subclass_of($className, 'Assert\LazyAssertionException')) {
             throw new LogicException($className . ' is not (a subclass of) Assert\LazyAssertionException');
         }
 

--- a/lib/Assert/LazyAssertionException.php
+++ b/lib/Assert/LazyAssertionException.php
@@ -28,11 +28,11 @@ class LazyAssertionException extends InvalidArgumentException
      */
     public static function fromErrors(array $errors)
     {
-        $message = sprintf('The following %d assertions failed:', count($errors)) . "\n";
+        $message = \sprintf('The following %d assertions failed:', \count($errors)) . "\n";
 
         $i = 1;
         foreach ($errors as $error) {
-            $message .= sprintf("%d) %s: %s\n", $i++, $error->getPropertyPath(), $error->getMessage());
+            $message .= \sprintf("%d) %s: %s\n", $i++, $error->getPropertyPath(), $error->getMessage());
         }
 
         return new static($message, $errors);

--- a/lib/Assert/functions.php
+++ b/lib/Assert/functions.php
@@ -14,7 +14,7 @@
 
 namespace Assert;
 
-if (!function_exists(__NAMESPACE__ . '\that')) {
+if (!\function_exists(__NAMESPACE__ . '\that')) {
     /**
      * Start validation on a value, returns {@link AssertionChain}.
      *
@@ -43,7 +43,7 @@ if (!function_exists(__NAMESPACE__ . '\that')) {
     }
 }
 
-if (!function_exists(__NAMESPACE__ . '\thatAll')) {
+if (!\function_exists(__NAMESPACE__ . '\thatAll')) {
     /**
      * Start validation on a set of values, returns {@link AssertionChain}.
      *
@@ -61,7 +61,7 @@ if (!function_exists(__NAMESPACE__ . '\thatAll')) {
     }
 }
 
-if (!function_exists(__NAMESPACE__ . '\thatNullOr')) {
+if (!\function_exists(__NAMESPACE__ . '\thatNullOr')) {
     /**
      * Start validation and allow NULL, returns {@link AssertionChain}.
      *
@@ -79,7 +79,7 @@ if (!function_exists(__NAMESPACE__ . '\thatNullOr')) {
     }
 }
 
-if (!function_exists(__NAMESPACE__ . '\lazy')) {
+if (!\function_exists(__NAMESPACE__ . '\lazy')) {
     /**
      * Create a lazy assertion object.
      *

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -95,7 +95,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
             array('test'),
             array(null),
             array('1.23'),
-            array(fopen(__FILE__, 'r')),
+            array(\fopen(__FILE__, 'r')),
         );
     }
 
@@ -484,7 +484,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
             array(1),
             array(1.23),
             array(new \stdClass()),
-            array(fopen('php://memory', 'r')),
+            array(\fopen('php://memory', 'r')),
         );
     }
 
@@ -877,10 +877,10 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotInArray()
     {
-        $this->assertTrue(Assertion::notInArray(6, range(1, 5)));
-        $this->assertTrue(Assertion::notInArray('a', range('b', 'z')));
+        $this->assertTrue(Assertion::notInArray(6, \range(1, 5)));
+        $this->assertTrue(Assertion::notInArray('a', \range('b', 'z')));
 
-        Assertion::notInArray(1, range(1, 5));
+        Assertion::notInArray(1, \range(1, 5));
     }
 
     public function testMin()
@@ -1055,7 +1055,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testWriteable()
     {
-        $this->assertTrue(Assertion::writeable(sys_get_temp_dir()));
+        $this->assertTrue(Assertion::writeable(\sys_get_temp_dir()));
 
         Assertion::writeable(__DIR__ . '/does-not-exist');
     }
@@ -1106,8 +1106,8 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     public static function isJsonStringDataprovider()
     {
         return array(
-            '»null« value' => array(json_encode(null)),
-            '»false« value' => array(json_encode(false)),
+            '»null« value' => array(\json_encode(null)),
+            '»false« value' => array(\json_encode(false)),
             'array value' => array('["false"]'),
             'object value' => array('{"tux":"false"}'),
         );
@@ -1611,7 +1611,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     public function testInvalidSatisfy()
     {
         Assertion::satisfy(null, function ($value) {
-            return !is_null($value);
+            return !\is_null($value);
         });
     }
 
@@ -1619,12 +1619,12 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         // Should not fail with true return
         $this->assertTrue(Assertion::satisfy(null, function ($value) {
-            return is_null($value);
+            return \is_null($value);
         }));
 
         // Should not fail with void return
         $this->assertTrue(Assertion::satisfy(true, function ($value) {
-            if (!is_bool($value)) {
+            if (!\is_bool($value)) {
                 return false;
             }
         }));
@@ -1834,7 +1834,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringifyTruncatesStringValuesLongerThan100CharactersAppropriately()
     {
-        $string = str_repeat('1234567890', 11);
+        $string = \str_repeat('1234567890', 11);
 
         $this->assertTrue(Assertion::float($string));
     }
@@ -1846,7 +1846,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      */
     public function testStringifyReportsResourceType()
     {
-        $this->assertTrue(Assertion::float(fopen('php://stdin', 'rb')));
+        $this->assertTrue(Assertion::float(\fopen('php://stdin', 'rb')));
     }
 
     public function testExtensionLoaded()

--- a/tests/Assert/Tests/AssertionChainFunctionsTest.php
+++ b/tests/Assert/Tests/AssertionChainFunctionsTest.php
@@ -71,7 +71,7 @@ class AssertionChainFunctionsTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('\Assert\AssertionChain', \Assert\that(null)->satisfy(
             function ($value) {
-                return is_null($value);
+                return \is_null($value);
             }
         ));
     }

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -72,7 +72,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('\Assert\AssertionChain', Assert::that(null)->satisfy(
             function ($value) {
-                return is_null($value);
+                return \is_null($value);
             }
         ));
     }
@@ -83,7 +83,7 @@ class AssertionChainTest extends \PHPUnit_Framework_TestCase
         $assertionChain->setAssertionClassName('Assert\Tests\Fixtures\CustomAssertion');
 
         CustomAssertion::clearCalls();
-        $message = uniqid();
+        $message = \uniqid();
         $assertionChain->string($message);
 
         $this->assertSame(array(array('string', 'foo')), CustomAssertion::getCalls());

--- a/tests/Assert/Tests/AssertionCodesUniqueTest.php
+++ b/tests/Assert/Tests/AssertionCodesUniqueTest.php
@@ -23,6 +23,6 @@ class AssertionCodesUniqueTest extends \PHPUnit_Framework_TestCase
         $assertReflection = new \ReflectionClass('Assert\Assertion');
         $constants = $assertReflection->getConstants();
 
-        $this->assertTrue(Assertion::eq(count($constants), count(array_unique($constants))));
+        $this->assertTrue(Assertion::eq(\count($constants), \count(\array_unique($constants))));
     }
 }

--- a/tests/Assert/Tests/AssertionExceptionCallbackTest.php
+++ b/tests/Assert/Tests/AssertionExceptionCallbackTest.php
@@ -27,7 +27,7 @@ class AssertionExceptionCallbackTest extends \PHPUnit_Framework_TestCase
         Assertion::string(
             M_PI,
             function (array $parameters) {
-                return sprintf(
+                return \sprintf(
                     'The assertion %s() failed for %s',
                     $parameters['::assertion'],
                     $parameters['value']
@@ -47,7 +47,7 @@ class AssertionExceptionCallbackTest extends \PHPUnit_Framework_TestCase
             M_PI,
             '`[A-Z]++`',
             function (array $parameters) {
-                return sprintf(
+                return \sprintf(
                     'The assertion %s() failed for %s',
                     $parameters['::assertion'],
                     $parameters['value']
@@ -67,7 +67,7 @@ class AssertionExceptionCallbackTest extends \PHPUnit_Framework_TestCase
             (string) M_PI,
             '`^[0-9]++$`',
             function (array $parameters) {
-                return sprintf(
+                return \sprintf(
                     'The assertion %s() failed for %s against the pattern %s',
                     $parameters['::assertion'],
                     $parameters['value'],

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -36,7 +36,7 @@ class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCustomAssertionsUsesCustomExceptionForAssertionChains()
     {
-        $string = 's' . uniqid();
+        $string = 's' . \uniqid();
         Fixtures\CustomAssert::that($string)->string();
         $this->assertSame(array(array('string', $string)), CustomAssertion::getCalls());
 

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -57,7 +57,7 @@ class LazyAssertionTest extends \PHPUnit_Framework_TestCase
                 'Value "10" expected to be string, type integer given.',
                 'Value "<NULL>" is empty, but non empty value was expected.',
                 'Value "string" is not an array.',
-            ), array_map(function (\Exception $ex) {
+            ), \array_map(function (\Exception $ex) {
                 return $ex->getMessage();
             }, $ex->getErrorExceptions()));
         }
@@ -82,7 +82,7 @@ class LazyAssertionTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals(array(
                 'must be int',
                 'must be between',
-            ), array_map(function (\Exception $ex) {
+            ), \array_map(function (\Exception $ex) {
                 return $ex->getMessage();
             }, $ex->getErrorExceptions()));
         }
@@ -133,7 +133,7 @@ class LazyAssertionTest extends \PHPUnit_Framework_TestCase
         $lazyAssertion = new LazyAssertion();
         $lazyAssertion->setExceptionClass('Assert\Tests\Fixtures\CustomLazyAssertionException');
 
-        var_dump($lazyAssertion
+        \var_dump($lazyAssertion
             ->that('foo', 'property')->integer()
             ->verifyNow()
         );


### PR DESCRIPTION
This PR

* [x] enables the `native_function_invocation` fixer
* [x] runs `composer assert:cs-fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.1.1#usage:

> **native_function_invocation**
Add leading `\` before function invocation of internal function to speed
up resolving.
Rule is: configurable, risky.

Also take a look at the description at https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2462.