### PR TITLE
Fix: Do not update composer itself more often than once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,8 @@ cache:
 
 before_install:
   - phpenv config-rm xdebug.ini || true
-  
+
 before_script:
-    - travis_retry composer self-update
     - travis_retry composer update --no-interaction --prefer-source --prefer-stable
 
 script:


### PR DESCRIPTION
This PR

* [x] removes a redundant run of `composer self-update` from `.travis.yml`

💁‍♂️ Travis updates composer twice

* https://travis-ci.org/beberlei/assert/jobs/208301839#L135
* https://travis-ci.org/beberlei/assert/jobs/208301839#L141

and we update it once more

* https://travis-ci.org/beberlei/assert/jobs/208301839#L173

