### PR TITLE
Fix: Disable and enable xdebug only when needed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.travis/ export-ignore
 .travis.yml export-ignore
 .scrutinzer.yml export-ignore
 bin/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - php: 5.6
     - php: 7.0
       env:
-      - LINT=true
+      - LINT=true COVERAGE=true
     - php: 7.1
       env:
       - LINT=true
@@ -31,8 +31,9 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_install:
-  - phpenv config-rm xdebug.ini || true
-  
+    - source .travis/xdebug.sh
+    - xdebug-disable
+
 before_script:
     - travis_retry composer self-update
     - travis_retry composer update --no-interaction --prefer-source --prefer-stable
@@ -44,7 +45,13 @@ script:
       composer require --dev phpstan/phpstan;
       vendor/bin/phpstan analyse --no-progress --ansi -l 5 lib;
     fi
-  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+  - if [[ "$COVERAGE" == "true" ]]; then
+        xdebug-enable;
+        vendor/bin/phpunit vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover;
+        xdebug-disable;
+    else
+        vendor/bin/phpunit;
+    fi
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis/xdebug.sh
+++ b/.travis/xdebug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# The problem is that we do not want to remove the configuration file, just disable it for a few tasks, then enable it
+#
+# For reference, see
+#
+# - https://docs.travis-ci.com/user/languages/php#Disabling-preinstalled-PHP-extensions
+# - https://docs.travis-ci.com/user/languages/php#Custom-PHP-configuration
+
+config="/home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
+
+function xdebug-disable() {
+    if [[ -f $config ]]; then
+        mv $config "$config.bak"
+    fi
+}
+
+function xdebug-enable() {
+    if [[ -f "$config.bak" ]]; then
+        mv "$config.bak" $config
+    fi
+}


### PR DESCRIPTION
This PR

* [x] disables `xdebug` and enables it for steps where we need it

💁‍♂️ As of the moment, the `xdebug` configuration is removed entirely and no coverage is generated, see

* https://travis-ci.org/beberlei/assert/jobs/208301839#L231-L232