### PR TITLE
Improve propertiesExist assertion

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -2243,6 +2243,7 @@ class Assertion
      */
     public static function propertiesExist($value, array $properties, $message = null, $propertyPath = null)
     {
+        static::objectOrClass($value);
         static::allString($properties, $message, $propertyPath);
 
         $invalidProperties = array();
@@ -2250,16 +2251,16 @@ class Assertion
             if (!\property_exists($value, $property)) {
                 $invalidProperties[] = $property;
             }
+        }
 
-            if ($invalidProperties) {
-                $message = \sprintf(
-                    static::generateMessage($message) ?: 'Class "%s" does not have these properties: %s.',
-                    static::stringify($value),
-                    static::stringify(\implode(', ', $invalidProperties))
-                );
+        if ($invalidProperties) {
+            $message = \sprintf(
+                static::generateMessage($message) ?: 'Class "%s" does not have these properties: %s.',
+                static::stringify($value),
+                static::stringify(\implode(', ', $invalidProperties))
+            );
 
-                throw static::createException($value, $message, static::INVALID_PROPERTY, $propertyPath);
-            }
+            throw static::createException($value, $message, static::INVALID_PROPERTY, $propertyPath);
         }
 
         return true;

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1945,7 +1945,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      * @expectedException \Assert\InvalidArgumentException
      * @expectedExceptionCode \Assert\Assertion::INVALID_PROPERTY
      */
-    public function testPropertyNotExists()
+    public function testInvalidPropertyExists()
     {
         Assertion::propertyExists(new \Exception(), 'invalidProperty');
     }
@@ -1954,7 +1954,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         self::assertTrue(Assertion::propertiesExist(new \Exception(), array('message', 'code', 'previous')));
     }
-    
+
     public function invalidPropertiesExistProvider()
     {
         return array(
@@ -1970,7 +1970,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
      *
      * @param array $properties
      */
-    public function testPropertiesNotExist($properties)
+    public function testInvalidPropertiesExist($properties)
     {
         Assertion::propertiesExist(new \Exception(), $properties);
     }

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1943,6 +1943,7 @@ class AssertTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Assert\InvalidArgumentException
+     * @expectedExceptionCode \Assert\Assertion::INVALID_PROPERTY
      */
     public function testPropertyNotExists()
     {
@@ -1953,12 +1954,24 @@ class AssertTest extends \PHPUnit_Framework_TestCase
     {
         self::assertTrue(Assertion::propertiesExist(new \Exception(), array('message', 'code', 'previous')));
     }
+    
+    public function invalidPropertiesExistProvider()
+    {
+        return array(
+            array(array('invalidProperty')),
+            array(array('invalidProperty', 'anotherInvalidProperty')),
+        );
+    }
 
     /**
+     * @dataProvider invalidPropertiesExistProvider
      * @expectedException \Assert\InvalidArgumentException
+     * @expectedExceptionCode \Assert\Assertion::INVALID_PROPERTY
+     *
+     * @param array $properties
      */
-    public function testPropertiesNotExist()
+    public function testPropertiesNotExist($properties)
     {
-        Assertion::propertiesExist(new \Exception(), array('invalidProperty'));
+        Assertion::propertiesExist(new \Exception(), $properties);
     }
 }


### PR DESCRIPTION
From reading the code of the `propertiesExists()` assertion I thought it might not work as intended. 

As the foreach loop breaks at the first invalid property encountered it hardly makes sense to store the invalid properties in an array. First collecting all the properties and then displaying all of them is also what I'd expect as a user.

Moreover and for consistency reasons, I added the `isObjectOrClass()` check at the beginning –which is also present in the `propertyExists()` method.

(usually I like more fine grained unit testing including the exception messages etc. but I didn't want to break the current pattern; if desired I can add some more of course)