### PR TITLE
Rename param to fix auto doc regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Assertion::choice(mixed $value, array $choices);
 Assertion::choicesNotEmpty(array $values, array $choices);
 Assertion::classExists(mixed $value);
 Assertion::contains(mixed $string, string $needle);
-Assertion::count(array|\Countable $countable, array|\Countable $count);
+Assertion::count(array|\Countable $countable, int $value);
 Assertion::date(string $value, string $format);
 Assertion::defined(mixed $constant);
 Assertion::digit(mixed $value);

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -30,7 +30,7 @@ use BadMethodCallException;
  * @method static bool allChoicesNotEmpty(array $values, array $choices, string|callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content for all values.
  * @method static bool allClassExists(mixed $value, string|callable $message = null, string $propertyPath = null) Assert that the class exists for all values.
  * @method static bool allContains(mixed $string, string $needle, string|callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars for all values.
- * @method static bool allCount(array|\Countable $countable, array|\Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count for all values.
+ * @method static bool allCount(array|\Countable $countable, int $value, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count for all values.
  * @method static bool allDate(string $value, string $format, string|callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format for all values.
  * @method static bool allDefined(mixed $constant, string|callable $message = null, string $propertyPath = null) Assert that a constant is defined for all values.
  * @method static bool allDigit(mixed $value, string|callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit for all values.
@@ -111,7 +111,7 @@ use BadMethodCallException;
  * @method static bool nullOrChoicesNotEmpty(array $values, array $choices, string|callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content or that the value is null.
  * @method static bool nullOrClassExists(mixed $value, string|callable $message = null, string $propertyPath = null) Assert that the class exists or that the value is null.
  * @method static bool nullOrContains(mixed $string, string $needle, string|callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars or that the value is null.
- * @method static bool nullOrCount(array|\Countable $countable, array|\Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count or that the value is null.
+ * @method static bool nullOrCount(array|\Countable $countable, int $value, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count or that the value is null.
  * @method static bool nullOrDate(string $value, string $format, string|callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format or that the value is null.
  * @method static bool nullOrDefined(mixed $constant, string|callable $message = null, string $propertyPath = null) Assert that a constant is defined or that the value is null.
  * @method static bool nullOrDigit(mixed $value, string|callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit or that the value is null.
@@ -1855,7 +1855,7 @@ class Assertion
      * Assert that the count of countable is equal to count.
      *
      * @param array|\Countable $countable
-     * @param int              $count
+     * @param int              $value
      * @param string|null      $message
      * @param string|null      $propertyPath
      *
@@ -1863,15 +1863,15 @@ class Assertion
      *
      * @throws \Assert\AssertionFailedException
      */
-    public static function count($countable, $count, $message = null, $propertyPath = null)
+    public static function count($countable, $value, $message = null, $propertyPath = null)
     {
-        if ($count !== \count($countable)) {
+        if ($value !== \count($countable)) {
             $message = \sprintf(
                 static::generateMessage($message) ?: 'List does not contain exactly "%d" elements.',
-                static::stringify($count)
+                static::stringify($value)
             );
 
-            throw static::createException($countable, $message, static::INVALID_COUNT, $propertyPath, array('count' => $count));
+            throw static::createException($countable, $message, static::INVALID_COUNT, $propertyPath, array('count' => $value));
         }
 
         return true;

--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -31,7 +31,7 @@ use ReflectionClass;
  * @method AssertionChain choicesNotEmpty(array $choices, string|callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content.
  * @method AssertionChain classExists(string|callable $message = null, string $propertyPath = null) Assert that the class exists.
  * @method AssertionChain contains(string $needle, string|callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars.
- * @method AssertionChain count(array|\Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count.
+ * @method AssertionChain count(int $value, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count.
  * @method AssertionChain date(string $format, string|callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format.
  * @method AssertionChain defined(string|callable $message = null, string $propertyPath = null) Assert that a constant is defined.
  * @method AssertionChain digit(string|callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit.

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -30,7 +30,7 @@ use LogicException;
  * @method LazyAssertion choicesNotEmpty(array $choices, string|callable $message = null, string $propertyPath = null) Determines if the values array has every choice as key and that this choice has content.
  * @method LazyAssertion classExists(string|callable $message = null, string $propertyPath = null) Assert that the class exists.
  * @method LazyAssertion contains(string $needle, string|callable $message = null, string $propertyPath = null, string $encoding = 'utf8') Assert that string contains a sequence of chars.
- * @method LazyAssertion count(array|\Countable $count, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count.
+ * @method LazyAssertion count(int $value, string $message = null, string $propertyPath = null) Assert that the count of countable is equal to count.
  * @method LazyAssertion date(string $format, string|callable $message = null, string $propertyPath = null) Assert that date is valid and corresponds to the given format.
  * @method LazyAssertion defined(string|callable $message = null, string $propertyPath = null) Assert that a constant is defined.
  * @method LazyAssertion digit(string|callable $message = null, string $propertyPath = null) Validates if an integer or integerish is a digit.


### PR DESCRIPTION
I was reading the docs for the `Assertion::count()` method and they incorrectly say:

`Assertion::count(array|\Countable $countable, array|\Countable $count);`

The second param should be an `int` however the auto doc generator's RegEx greedily takes the param type for the first item that _starts with_ the param name. In this case, `$countable` always wins because it starts with `$count`.

In the long run the doc generator should probably be adjusted but in the short term, since `$value` is used elsewhere I thought this would be a simpler change.