### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.1.1",
-    "phpunit/phpunit": "^4|^5"
+    "phpunit/phpunit": "^4.8.35|^5.7"
   },
   "autoload": {
     "psr-4": {

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -16,8 +16,9 @@ namespace Assert\Tests;
 
 use Assert\Assertion;
 use Assert\AssertionFailedException;
+use PHPUnit\Framework\TestCase;
 
-class AssertTest extends \PHPUnit_Framework_TestCase
+class AssertTest extends TestCase
 {
     public static function dataInvalidFloat()
     {

--- a/tests/Assert/Tests/AssertionChainFunctionsTest.php
+++ b/tests/Assert/Tests/AssertionChainFunctionsTest.php
@@ -14,10 +14,12 @@
 
 namespace Assert\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test case specific for the deprecated functions creating assertion chains.
  */
-class AssertionChainFunctionsTest extends \PHPUnit_Framework_TestCase
+class AssertionChainFunctionsTest extends TestCase
 {
     public function testThatAssertionChainFunctionsReturnAnAssertionChain()
     {

--- a/tests/Assert/Tests/AssertionChainTest.php
+++ b/tests/Assert/Tests/AssertionChainTest.php
@@ -17,8 +17,9 @@ namespace Assert\Tests;
 use Assert\Assert;
 use Assert\AssertionChain;
 use Assert\Tests\Fixtures\CustomAssertion;
+use PHPUnit\Framework\TestCase;
 
-class AssertionChainTest extends \PHPUnit_Framework_TestCase
+class AssertionChainTest extends TestCase
 {
     public function testThatAssertionChainReturnAnAssertionChain()
     {

--- a/tests/Assert/Tests/AssertionCodesUniqueTest.php
+++ b/tests/Assert/Tests/AssertionCodesUniqueTest.php
@@ -15,8 +15,9 @@
 namespace Assert\Tests;
 
 use Assert\Assertion;
+use PHPUnit\Framework\TestCase;
 
-class AssertionCodesUniqueTest extends \PHPUnit_Framework_TestCase
+class AssertionCodesUniqueTest extends TestCase
 {
     public function testAssertionCodesAreUnique()
     {

--- a/tests/Assert/Tests/AssertionExceptionCallbackTest.php
+++ b/tests/Assert/Tests/AssertionExceptionCallbackTest.php
@@ -15,8 +15,9 @@
 namespace Assert\Tests;
 
 use Assert\Assertion;
+use PHPUnit\Framework\TestCase;
 
-class AssertionExceptionCallbackTest extends \PHPUnit_Framework_TestCase
+class AssertionExceptionCallbackTest extends TestCase
 {
     /**
      * @expectedException \Assert\AssertionFailedException

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -15,8 +15,9 @@
 namespace Assert\Tests;
 
 use Assert\Tests\Fixtures\CustomAssertion;
+use PHPUnit\Framework\TestCase;
 
-class CustomAssertionClassTest extends \PHPUnit_Framework_TestCase
+class CustomAssertionClassTest extends TestCase
 {
     protected function setUp()
     {

--- a/tests/Assert/Tests/LazyAssertionTest.php
+++ b/tests/Assert/Tests/LazyAssertionTest.php
@@ -17,8 +17,9 @@ namespace Assert\Tests;
 use Assert\Assert;
 use Assert\LazyAssertion;
 use Assert\LazyAssertionException;
+use PHPUnit\Framework\TestCase;
 
-class LazyAssertionTest extends \PHPUnit_Framework_TestCase
+class LazyAssertionTest extends TestCase
 {
     /**
      * @expectedException \Assert\LazyAssertionException

--- a/tests/Assert/Tests/PR142_AllowOverridingStringifyTest.php
+++ b/tests/Assert/Tests/PR142_AllowOverridingStringifyTest.php
@@ -16,8 +16,9 @@ namespace Assert\Tests;
 
 use Assert\Assertion;
 use Assert\AssertionFailedException;
+use PHPUnit\Framework\TestCase;
 
-class PR142_AllowOverridingStringifyTest extends \PHPUnit_Framework_TestCase
+class PR142_AllowOverridingStringifyTest extends TestCase
 {
     public static function dataInvalidString()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.