### PR TITLE
Usage of custom extended Assert class in LazyAssertion

### DIFF
--- a/lib/Assert/Assert.php
+++ b/lib/Assert/Assert.php
@@ -92,6 +92,7 @@ abstract class Assert
         $lazyAssertion = new LazyAssertion();
 
         return $lazyAssertion
+            ->setAssertClass(get_called_class())
             ->setExceptionClass(static::$lazyAssertionExceptionClass)
         ;
     }

--- a/lib/Assert/LazyAssertion.php
+++ b/lib/Assert/LazyAssertion.php
@@ -114,6 +114,9 @@ class LazyAssertion
     private $currentChain;
     private $errors = array();
 
+    /** @var string The class to use as AssertionChain factory */
+    private $assertClass = 'Assert\Assert';
+
     /** @var string|LazyAssertionException The class to use for exceptions */
     private $exceptionClass = 'Assert\LazyAssertionException';
 
@@ -121,7 +124,8 @@ class LazyAssertion
     {
         $this->currentChainFailed = false;
         $this->thisChainTryAll = false;
-        $this->currentChain = Assert::that($value, $defaultMessage, $propertyPath);
+        $assertClass = $this->assertClass;
+        $this->currentChain = $assertClass::that($value, $defaultMessage, $propertyPath);
 
         return $this;
     }
@@ -168,6 +172,26 @@ class LazyAssertion
         }
 
         return true;
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return $this
+     */
+    public function setAssertClass($className)
+    {
+        if (!\is_string($className)) {
+            throw new LogicException('Assert class name must be passed as a string');
+        }
+
+        if ('Assert\Assert' !== $className && !\is_subclass_of($className, 'Assert\Assert')) {
+            throw new LogicException($className . ' is not (a subclass of) Assert\Assert');
+        }
+
+        $this->assertClass = $className;
+
+        return $this;
     }
 
     /**

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -68,6 +68,17 @@ class CustomAssertionClassTest extends TestCase
         ;
     }
 
+    public function testThatCustomLazyAssertionUsesCustomAssertion()
+    {
+        $string = 's' . \uniqid();
+        Fixtures\CustomAssert::lazy()
+            ->that($string, 'foo')->string()
+            ->verifyNow()
+        ;
+
+        $this->assertSame(array(array('string', $string)), CustomAssertion::getCalls());
+    }
+
     public function testThatCustomLazyAssertionContainsOnlyCustomAssertionExceptions()
     {
         try {
@@ -84,7 +95,7 @@ class CustomAssertionClassTest extends TestCase
      * @expectedException \Assert\Tests\Fixtures\CustomLazyAssertionException
      * @expectedExceptionMessageRegex /The following 4 assertions failed:\s+1) foo: Value "foo" is not an integer.\s+2) foo: Value "foo" is not an array.\s+3) bar: Value "123" expected to be string, type integer given.\s+4) bar: Value "123" is not an array./
      */
-    public function testThatCustomAsserionsExceptionsForLazyAssertionChainsTryAllTheAssertionsPerChain()
+    public function testThatCustomAssertionsExceptionsForLazyAssertionChainsTryAllTheAssertionsPerChain()
     {
         Fixtures\CustomAssert::lazy()
             ->that('foo', 'foo')->tryAll()->integer()->isArray()
@@ -97,7 +108,7 @@ class CustomAssertionClassTest extends TestCase
      * @expectedException \Assert\Tests\Fixtures\CustomLazyAssertionException
      * @expectedExceptionMessageRegex /The following 4 assertions failed:\s+1) foo: Value "foo" is not an integer.\s+2) foo: Value "foo" is not an array.\s+3) bar: Value "123" expected to be string, type integer given.\s+4) bar: Value "123" is not an array./
      */
-    public function testThatCustomAsserionsExceptionsForLazyAssertionChainsTryAllTheAssertions()
+    public function testThatCustomAssertionsExceptionsForLazyAssertionChainsTryAllTheAssertions()
     {
         Fixtures\CustomAssert::lazy()
             ->tryAll()

--- a/tests/Assert/Tests/CustomAssertionClassTest.php
+++ b/tests/Assert/Tests/CustomAssertionClassTest.php
@@ -14,6 +14,7 @@
 
 namespace Assert\Tests;
 
+use Assert\LazyAssertionException;
 use Assert\Tests\Fixtures\CustomAssertion;
 use PHPUnit\Framework\TestCase;
 
@@ -65,6 +66,18 @@ class CustomAssertionClassTest extends TestCase
             ->that('bar', 'bar')->integer()
             ->verifyNow()
         ;
+    }
+
+    public function testThatCustomLazyAssertionContainsOnlyCustomAssertionExceptions()
+    {
+        try {
+            Fixtures\CustomAssert::lazy()
+                ->that('foo', 'foo')->integer()
+                ->verifyNow()
+            ;
+        } catch (LazyAssertionException $ex) {
+            $this->assertContainsOnlyInstancesOf('\Assert\Tests\Fixtures\CustomException', $ex->getErrorExceptions());
+        }
     }
 
     /**


### PR DESCRIPTION
The main reason was to make custom LazyAssertionException classes contain only instances of custom AssertionException classes

But it should also use the whole custom Assertion because it could contain newly added assertion methods.
