### PR TITLE
Force LF line endings when cloning this repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-*           text=auto
+*           text=auto   eol=lf
 
 .editorconfig export-ignore
 .gitattributes export-ignore


### PR DESCRIPTION
When trying to contribute on Windows, the linter complains about bad CRLF line endings which prevents contributors from seeing other problems possibly introduced to the codebase. 

I have added the `eol=lf` to the `.gitattributes` so Git always uses the LF line endings regardles of local `autocrlf` settings.

Read more on [SO](https://stackoverflow.com/a/42135910/878514).