### PR TITLE
Prevent date overflow in Assertion::date() by reset preset date value

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -2208,7 +2208,7 @@ class Assertion
         static::string($value, $message, $propertyPath);
         static::string($format, $message, $propertyPath);
 
-        $dateTime = \DateTime::createFromFormat($format, $value);
+        $dateTime = \DateTime::createFromFormat('!' . $format, $value);
 
         if (false === $dateTime || $value !== $dateTime->format($format)) {
             $message = \sprintf(


### PR DESCRIPTION
This PR fixes a date format assertion bug or gotcha caused by `DateTime::createFromFormat()`.

For example, `Assertion::date('2018-04', 'Y-m')` would throw in May 31 2018.
See 
https://stackoverflow.com/questions/21473817/wrong-month-february-datetimecreatefromformat#21473903.

The applied solution was [prepending '!' to user specified format](https://stackoverflow.com/questions/21473817/wrong-month-february-datetimecreatefromformat#comment62588130_21473897) before passing it to createFromFormat().
Apparently, it's not a problem if we have duplicated '!' s in a format string.