### PR TITLE
Removed aliasOf annotation that caused an exception

### DIFF
--- a/bin/generate_method_docs.php
+++ b/bin/generate_method_docs.php
@@ -48,7 +48,7 @@ class MethodDocGenerator
             $shortDescription = \trim(\substr($descriptionLine, 7), '.');
             $methodName = $prefix.($prefix ? \ucfirst($method->getName()) : $method->getName());
 
-            if (\preg_match('`\* @aliasOf (?P<aliasOf>[^\s]++)`sim', $doc, $aliasMatch)) {
+            if (\preg_match('`\* This is an alias of {@see (?P<aliasOf>[^\s\}]++)`sim', $doc, $aliasMatch)) {
                 $shortDescription .= \sprintf('. This is an alias of Assertion::%s()', \trim($aliasMatch['aliasOf'], '(){}'));
             }
 

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -983,8 +983,6 @@ class Assertion
      *
      * This is an alias of {@see choice()}.
      *
-     * @aliasOf choice()
-     *
      * @param mixed                $value
      * @param array                $choices
      * @param string|callable|null $message


### PR DESCRIPTION
Removed aliasOf annotation that caused an exception in Doctrine DocParser.
This is related with [this issue](https://github.com/beberlei/assert/issues/251)