### PR TITLE
An `AssertionFailedException` must be a `Throwable`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ git:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
     - php: 7.0
       env:
       - LINT=true COVERAGE=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ script:
   - if [[ "$LINT" == "true" ]]; then
       composer assert:cs-lint;
       ./bin/travis/lint-docs;
-      composer require --dev phpstan/phpstan;
       vendor/bin/phpstan analyse --no-progress --ansi -l 7 lib;
     fi
   - if [[ "$COVERAGE" == "true" ]]; then

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.1.1",
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7",
+    "phpstan/phpstan": "^0.9.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=5.3",
+    "php": "^7",
     "ext-mbstring": "*"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.1.1",
-    "phpunit/phpunit": "^4.8.35|^5.7"
+    "phpunit/phpunit": "^5.7"
   },
   "autoload": {
     "psr-4": {

--- a/lib/Assert/AssertionFailedException.php
+++ b/lib/Assert/AssertionFailedException.php
@@ -14,7 +14,9 @@
 
 namespace Assert;
 
-interface AssertionFailedException
+use Throwable;
+
+interface AssertionFailedException extends Throwable
 {
     public function getPropertyPath();
 

--- a/tests/Assert/Tests/AssertionFailedExceptionTest.php
+++ b/tests/Assert/Tests/AssertionFailedExceptionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Assert
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Assert\Tests;
+
+use Assert\AssertionFailedException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Throwable;
+
+final class AssertionFailedExceptionTest extends TestCase
+{
+    public function testMarkerInterfaceIsAValidThrowable()
+    {
+        self::assertTrue(
+            (new ReflectionClass(AssertionFailedException::class))
+                ->implementsInterface(Throwable::class)
+        );
+    }
+}


### PR DESCRIPTION
Since `Throwable` is also available starting from PHP 7.0, bumped dependency
requirement, as 5.x is being retired anyway.