### PR TITLE
Refactor notEq, notSame and notInArray assertion messages

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -358,7 +358,7 @@ class Assertion
     {
         if ($value1 == $value2) {
             $message = \sprintf(
-                static::generateMessage($message ?: 'Value "%s" is equal to expected value "%s".'),
+                static::generateMessage($message ?: 'Value "%s" was not expected to be equal to value "%s".'),
                 static::stringify($value1),
                 static::stringify($value2)
             );
@@ -384,7 +384,7 @@ class Assertion
     {
         if ($value1 === $value2) {
             $message = \sprintf(
-                static::generateMessage($message ?: 'Value "%s" is the same as expected value "%s".'),
+                static::generateMessage($message ?: 'Value "%s" was not expected to be the same as value "%s".'),
                 static::stringify($value1),
                 static::stringify($value2)
             );
@@ -410,7 +410,7 @@ class Assertion
     {
         if (true === \in_array($value, $choices)) {
             $message = \sprintf(
-                static::generateMessage($message ?: 'Value "%s" is in given "%s".'),
+                static::generateMessage($message ?: 'Value "%s" was not expected to be an element of the values: %s'),
                 static::stringify($value),
                 static::stringify($choices)
             );


### PR DESCRIPTION
### Context
Fixes #258 
I figured this would be the best way to formulate the message (judging by other examples in your library).

However, I also noticed the constraints put into the exceptions are now still done with the key `expected`. I would change this (not sure to what), but that could have impact because it's technically a BC break.

What do you think?