### PR TITLE
Update Assertion.php  Assertion::stringify

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -2768,8 +2768,8 @@ class Assertion
         } elseif (\is_scalar($value)) {
             $val = (string)$value;
 
-            if (\strlen($val) > 100) {
-                $val = \substr($val, 0, 97).'...';
+            if (\mb_strlen($val) > 100) {
+                $val = \mb_substr($val, 0, 97).'...';
             }
 
             $result = $val;


### PR DESCRIPTION
Currently asserting string length with a UTF-8  string will cause a message like this: 

![image](https://user-images.githubusercontent.com/1427433/65948951-1a357500-e448-11e9-8773-9a7c6c139d28.png)

which contains an invalid UTF-8 character. it's because of substr function ( it's not UTF-8 safe )

I fixed this issue by using mb_substr instead of substr