### PR TITLE
Allow any value to be passed to Assertion::isCountable()

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1118,7 +1118,7 @@ class Assertion
 
         if (!$assert) {
             $message = \sprintf(
-       value` argument         static::generateMessage($message ?: 'Value "%s" is not an array and does not implement Countable.'),
+                static::generateMessage($message ?: 'Value "%s" is not an array and does not implement Countable.'),
                 static::stringify($value)
             );
 

--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1103,7 +1103,7 @@ class Assertion
     /**
      * Assert that value is countable.
      *
-     * @param array|Countable|ResourceBundle|SimpleXMLElement $value
+     * @param mixed $value
      * @param string|callable|null $message
      *
      * @throws AssertionFailedException
@@ -1118,7 +1118,7 @@ class Assertion
 
         if (!$assert) {
             $message = \sprintf(
-                static::generateMessage($message ?: 'Value "%s" is not an array and does not implement Countable.'),
+       value` argument         static::generateMessage($message ?: 'Value "%s" is not an array and does not implement Countable.'),
                 static::stringify($value)
             );
 


### PR DESCRIPTION
Static analysis tools complain about type of `$value` argument but in fact it could be of any type since it will be checked later (that's the purpose of the method).