### PR TITLE
Fix alnum() assertion only allowed strings that started with a character

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1775,7 +1775,7 @@ class Assertion
     public static function alnum($value, $message = null, string $propertyPath = null): bool
     {
         try {
-            static::regex($value, '(^([a-zA-Z]{1}[a-zA-Z0-9]*)$)', $message, $propertyPath);
+            static::regex($value, '(^([a-zA-Z0-9]*)$)', $message, $propertyPath);
         } catch (Throwable $e) {
             $message = \sprintf(
                 static::generateMessage($message ?: 'Value "%s" is not alphanumeric, starting with letters and containing only letters and numbers.'),

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -849,13 +849,14 @@ class AssertTest extends TestCase
         $this->assertTrue(Assertion::alnum('a1'));
         $this->assertTrue(Assertion::alnum('aasdf1234'));
         $this->assertTrue(Assertion::alnum('a1b2c3'));
+        $this->assertTrue(Assertion::alnum('1234567890'));
     }
 
     public function testInvalidAlnum()
     {
         $this->expectException('Assert\AssertionFailedException');
         $this->expectExceptionCode(\Assert\Assertion::INVALID_ALNUM);
-        Assertion::alnum('1a');
+        Assertion::alnum('_1a');
     }
 
     public function testValidTrue()


### PR DESCRIPTION
# Related Issue
#78 