### PR TITLE
Add more specific (static) return type to docblock

### DIFF
--- a/lib/Assert/LazyAssertionException.php
+++ b/lib/Assert/LazyAssertionException.php
@@ -23,6 +23,8 @@ class LazyAssertionException extends InvalidArgumentException
 
     /**
      * @param InvalidArgumentException[] $errors
+     *
+     * @return static
      */
     public static function fromErrors(array $errors): self
     {


### PR DESCRIPTION
I have an exception that extends `\Assert\LazyAssertionException` and currently [psalm](https://psalm.dev/) is reporting 2 error related to the return type: ` MoreSpecificReturnType` and `LessSpecificReturnStatement`.