### PR TITLE
Improve performance of Assertion Chain class

### DIFF
--- a/lib/Assert/AssertionChain.php
+++ b/lib/Assert/AssertionChain.php
@@ -15,7 +15,6 @@
 namespace Assert;
 
 use LogicException;
-use ReflectionClass;
 
 /**
  * Chaining builder for assertions.
@@ -171,12 +170,11 @@ class AssertionChain
             return $this;
         }
 
-        if (!\method_exists($this->assertionClassName, $methodName)) {
+        try {
+            $method = new \ReflectionMethod($this->assertionClassName, $methodName);
+        } catch (\ReflectionException $exception) {
             throw new \RuntimeException("Assertion '".$methodName."' does not exist.");
         }
-
-        $reflClass = new ReflectionClass($this->assertionClassName);
-        $method = $reflClass->getMethod($methodName);
 
         \array_unshift($args, $this->value);
         $params = $method->getParameters();
@@ -186,12 +184,13 @@ class AssertionChain
                 continue;
             }
 
-            if ('message' == $param->getName()) {
-                $args[$idx] = $this->defaultMessage;
-            }
-
-            if ('propertyPath' == $param->getName()) {
-                $args[$idx] = $this->defaultPropertyPath;
+            switch ($param->getName()) {
+                case 'message':
+                    $args[$idx] = $this->defaultMessage;
+                    break;
+                case 'propertyPath':
+                    $args[$idx] = $this->defaultPropertyPath;
+                    break;
             }
         }
 


### PR DESCRIPTION
Hello! 

During testing performance of the package with PHPBench I've realised that Reflections methods and checking if method exists takes a lot of time. With the simple fixes we can cut execution time by around 10-15% for lazy assertions. 

Benchmark can be found here: [scyzoryck/php-validators-benchmark](https://github.com/scyzoryck/php-validators-benchmark/blob/master/benchmarks/Beberlei/BeberleiLazyAssertBench.php)

I'm attaching blackfire profiles:
- [Before - 3.64s](https://blackfire.io/profiles/a89a7ccf-1508-430f-bf76-bc5734564dd4/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main())
- [After - 2.85s](https://blackfire.io/profiles/50d53474-8c48-4e52-b556-80144f4075e0/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main())