### PR TITLE
Assertion::classExists() emits a PHP Warning

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1857,7 +1857,7 @@ class Assertion
      */
     public static function classExists($value, $message = null, string $propertyPath = null): bool
     {
-        if (!\class_exists($value)) {
+        if (!\is_string($value) || !\class_exists($value)) {
             $message = \sprintf(
                 static::generateMessage($message ?: 'Class "%s" does not exist.'),
                 static::stringify($value)


### PR DESCRIPTION
asserting an expression with classExists(), and the expression is an array,
it shows me the following warning:

> PHP Warning:  class_exists() expects parameter 1 to be string, array
> given in beberlei/assert/lib/Assert/Assertion.php on line 1860

on beberlei/assert v3.3.2 with php 7.4

and with php 8.0

> PHP Fatal error:  Uncaught TypeError: class_exists(): Argument #1 (
> $class) must be of type string, array given in [...] Assertion.php:1860

add an is_string check.