### PR TITLE
Fix notInArray Rule Error Message

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -440,7 +440,7 @@ class Assertion
             $message = \sprintf(
                 static::generateMessage($message ?: 'Value "%s" was not expected to be an element of the values: %s'),
                 static::stringify($value),
-                static::stringify($choices)
+                \implode(', ', \array_map([\get_called_class(), 'stringify'], $choices))
             );
             throw static::createException($value, $message, static::INVALID_VALUE_IN_ARRAY, $propertyPath, ['choices' => $choices]);
         }


### PR DESCRIPTION
I'm getting `<ARRAY>` in my error message when using `notInArray`.

I think it should match the formatting in `inArray`, so I've copied that line.

Before and after screenshots:

![image](https://user-images.githubusercontent.com/102683359/212361278-78ddc01c-2e3d-4ed5-9206-642e6c1fcd98.png)

![image](https://user-images.githubusercontent.com/102683359/212361433-779c6843-84e4-4a79-acf0-cc6aabfe1db2.png)
