### PR TITLE
Exclude github folder in gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.github/ export-ignore
 .php_cs export-ignore
 .travis/ export-ignore
 .travis.yml export-ignore


### PR DESCRIPTION
Hello @beberlei,

I saw the .github folder was not excluded in the gitattributes
I think it can be added (or is there a reason against ?)

Thanks !