### PR TITLE
Bump minimum PHP requirement to PHP 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "sort-packages": true
   },
   "require": {
-    "php": "^7.0 || ^8.0",
+    "php": "^7.1 || ^8.0",
     "ext-simplexml": "*",
     "ext-mbstring": "*",
     "ext-ctype": "*",


### PR DESCRIPTION
PR #337 depends on this.

Bumps the minimum required PHP version to PHP 7.1 to use explicit nullable parameter type syntax.