### PR TITLE
Add string validation to isJsonString assertion

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1950,6 +1950,8 @@ class Assertion
      */
     public static function isJsonString($value, $message = null, ?string $propertyPath = null): bool
     {
+        static::string($value, $message, $propertyPath);
+
         if (null === \json_decode($value) && JSON_ERROR_NONE !== \json_last_error()) {
             $message = \sprintf(
                 static::generateMessage($message ?: 'Value "%s" is not a valid JSON string.'),

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -1224,6 +1224,13 @@ class AssertTest extends TestCase
         ];
     }
 
+    public function testIsJsonStringNotString()
+    {
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(\Assert\Assertion::INVALID_STRING);
+        Assertion::isJsonString(4);
+    }
+
     /**
      * @dataProvider providesValidUuids
      *


### PR DESCRIPTION
`Assertion::isJsonString` returns `true` if the value is not a string but is an accepted argument for the `json_decode` function. This is possible because the library works in non-strict mode, so PHP does not raise an error if a non-string argument is passed to `json_decode`.

## Current behavior
None of these throw an exception:

```php
Assert::that(true)->isJsonString();
Assert::that(10)->isJsonString();
Assert::that(2.5)->isJsonString();
```

## Expected behavior
All of the above should throw `AssertionFailedException`

## Psalm
Because the function is annotated with `@psalm-assert =string $value`, Psalm does not raise an issue with this snippet:
```php
declare(strict_types=1);

function test(mixed $value): string {
    Assertion::isJsonString($value);

    return $value;
}

echo test(5);
``` 
This will actually fail at runtime with `Fatal error: Uncaught TypeError: test(): Return value must be of type string, int returned`. My PR changes this, so `AssertionFailedException` is thrown instead. 

## Backward compatibility
This will be a BC break if someone used the assertion with non-string arguments. On the other hand, description clearly suggests that this assertion should be performed for strings.