### PR TITLE
Reject trailing newline in alnum, url and e164

### DIFF
--- a/lib/Assert/Assertion.php
+++ b/lib/Assert/Assertion.php
@@ -1748,7 +1748,7 @@ class Assertion
             (?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*          # a path
             (?:\? (?:[\pL\pN\-._\~!$&\'\[\]()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a query (optional)
             (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?       # a fragment (optional)
-        $~ixu';
+        $~ixuD';
 
         $pattern = \sprintf($pattern, \implode('|', $protocols));
 
@@ -1775,7 +1775,7 @@ class Assertion
     public static function alnum($value, $message = null, ?string $propertyPath = null): bool
     {
         try {
-            static::regex($value, '(^([a-zA-Z]{1}[a-zA-Z0-9]*)$)', $message, $propertyPath);
+            static::regex($value, '(^([a-zA-Z]{1}[a-zA-Z0-9]*)$)D', $message, $propertyPath);
         } catch (Throwable $e) {
             $message = \sprintf(
                 static::generateMessage($message ?: 'Value "%s" is not alphanumeric, starting with letters and containing only letters and numbers.'),
@@ -2004,7 +2004,7 @@ class Assertion
      */
     public static function e164($value, $message = null, ?string $propertyPath = null): bool
     {
-        if (!\preg_match('/^\+?[1-9]\d{1,14}$/', $value)) {
+        if (!\preg_match('/^\+?[1-9]\d{1,14}$/D', $value)) {
             $message = \sprintf(
                 static::generateMessage($message ?: 'Value "%s" is not a valid E164.'),
                 static::stringify($value)

--- a/tests/Assert/Tests/AssertTest.php
+++ b/tests/Assert/Tests/AssertTest.php
@@ -782,6 +782,7 @@ class AssertTest extends TestCase
             ['http://:password@@symfony.com'],
             ['http://username:passwordsymfony.com'],
             ['http://usern@me:password@symfony.com'],
+            ["http://www.google.com\n"],
         ];
     }
 
@@ -896,6 +897,13 @@ class AssertTest extends TestCase
         $this->expectException('Assert\AssertionFailedException');
         $this->expectExceptionCode(\Assert\Assertion::INVALID_ALNUM);
         Assertion::alnum('1a');
+    }
+
+    public function testInvalidAlnumWithTrailingNewline()
+    {
+        $this->expectException('Assert\AssertionFailedException');
+        $this->expectExceptionCode(\Assert\Assertion::INVALID_ALNUM);
+        Assertion::alnum("a1b2c3\n");
     }
 
     public function testValidTrue()
@@ -1306,6 +1314,7 @@ class AssertTest extends TestCase
         return [
             ['+3362652569e'],
             ['+3361231231232652569'],
+            ["+33626525690\n"],
         ];
     }
 


### PR DESCRIPTION
Add PCRE_DOLLAR_ENDONLY modifier to disallow strings with trailing newlines.

Asserts that wrap PHP functions like numeric("123\n") are untouched.